### PR TITLE
增加 IoC 容器 & 依赖注入支持

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "dragonmantank/cron-expression": "^3.3",
         "jelix/version": "^2.0",
         "koriym/attributes": "^1.0",
+        "psr/container": "^2.0",
         "psy/psysh": "^0.11.2",
         "symfony/console": "~5.0 || ~4.0 || ~3.0",
         "symfony/polyfill-ctype": "^1.19",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,5 +7,6 @@ parameters:
     - '#Used constant OS_TYPE_(LINUX|WINDOWS) not found#'
     - '#Constant .* not found#'
     - '#PHPDoc tag @throws with type Psr\\Container\\ContainerExceptionInterface is not subtype of Throwable#'
+    - '#Unsafe usage of new static#'
   dynamicConstantNames:
     - SWOOLE_VERSION

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,5 +6,6 @@ parameters:
   ignoreErrors:
     - '#Used constant OS_TYPE_(LINUX|WINDOWS) not found#'
     - '#Constant .* not found#'
+    - '#PHPDoc tag @throws with type Psr\\Container\\ContainerExceptionInterface is not subtype of Throwable#'
   dynamicConstantNames:
     - SWOOLE_VERSION

--- a/src/Module/Example/Hello.php
+++ b/src/Module/Example/Hello.php
@@ -12,15 +12,12 @@ use ZM\Annotation\Http\RequestMapping;
 use ZM\Annotation\Swoole\OnCloseEvent;
 use ZM\Annotation\Swoole\OnOpenEvent;
 use ZM\Annotation\Swoole\OnRequestEvent;
-use ZM\Annotation\Swoole\OnStart;
 use ZM\API\CQ;
 use ZM\API\OneBotV11;
 use ZM\API\TuringAPI;
 use ZM\Config\ZMConfig;
 use ZM\ConnectionManager\ConnectionObject;
 use ZM\Console\Console;
-use ZM\Container\WorkerContainer;
-use ZM\Context\ContextInterface;
 use ZM\Event\EventDispatcher;
 use ZM\Exception\InterruptException;
 use ZM\Module\QQBot;
@@ -30,7 +27,6 @@ use ZM\Utils\ZMUtil;
 
 /**
  * Class Hello
- *
  * @since 2.0
  */
 class Hello
@@ -138,7 +134,6 @@ class Hello
      * 问法2：从1到20的随机数
      * @CQCommand("随机数")
      * @CQCommand(pattern="*从*到*的随机数")
-     *
      * @return string
      */
     public function randNum()
@@ -176,7 +171,6 @@ class Hello
     /**
      * 使用自定义参数的路由参数
      * @RequestMapping("/whoami/{name}")
-     *
      * @param  array  $param 参数
      * @return string 返回的 HTML Body
      */
@@ -188,7 +182,6 @@ class Hello
     /**
      * 在机器人连接后向终端输出信息
      * @OnOpenEvent("qq")
-     *
      * @param ConnectionObject $conn WebSocket 连接对象
      */
     public function onConnect(ConnectionObject $conn)
@@ -208,7 +201,6 @@ class Hello
     /**
      * 阻止 Chrome 自动请求 /favicon.ico 导致的多条请求并发和干扰
      * @OnRequestEvent(rule="ctx()->getRequest()->server['request_uri'] == '/favicon.ico'",level=200)
-     *
      * @throws InterruptException
      */
     public function onRequest()

--- a/src/Module/Example/Hello.php
+++ b/src/Module/Example/Hello.php
@@ -12,12 +12,15 @@ use ZM\Annotation\Http\RequestMapping;
 use ZM\Annotation\Swoole\OnCloseEvent;
 use ZM\Annotation\Swoole\OnOpenEvent;
 use ZM\Annotation\Swoole\OnRequestEvent;
+use ZM\Annotation\Swoole\OnStart;
 use ZM\API\CQ;
 use ZM\API\OneBotV11;
 use ZM\API\TuringAPI;
 use ZM\Config\ZMConfig;
 use ZM\ConnectionManager\ConnectionObject;
 use ZM\Console\Console;
+use ZM\Container\WorkerContainer;
+use ZM\Context\ContextInterface;
 use ZM\Event\EventDispatcher;
 use ZM\Exception\InterruptException;
 use ZM\Module\QQBot;
@@ -243,5 +246,32 @@ class Hello
     public function proxy()
     {
         bot()->all()->allGroups()->sendGroupMsg(0, ctx()->getMessage());
+    }
+
+    /*
+     * @OnStart(-1)
+     */
+    #[OnStart(-1)]
+    public function initContainer()
+    {
+        $worker_container = new WorkerContainer();
+        $worker_container->bindIf('echo', function ($container, $parameters) {
+            return 'Hello, ' . $parameters[0];
+        });
+        container()->bind(ContextInterface::class, function () {
+            return ctx();
+        });
+    }
+
+    /**
+     * 容器呐
+     *
+     * @CQCommand("container")
+     */
+    #[CQCommand('container')]
+    public function container(): string
+    {
+        resolve(ContextInterface::class)->reply('Good'); // ctx()->reply('good')
+        return resolve('echo', ['hello']); // Hello, hello
     }
 }

--- a/src/Module/Example/Hello.php
+++ b/src/Module/Example/Hello.php
@@ -18,6 +18,7 @@ use ZM\API\TuringAPI;
 use ZM\Config\ZMConfig;
 use ZM\ConnectionManager\ConnectionObject;
 use ZM\Console\Console;
+use ZM\Context\Context;
 use ZM\Event\EventDispatcher;
 use ZM\Exception\InterruptException;
 use ZM\Module\QQBot;
@@ -69,7 +70,6 @@ class Hello
      */
     public function hello()
     {
-        zm_dump(resolve('swoole_server')->worker_id);
         return '你好啊，我是由炸毛框架构建的机器人！';
     }
 
@@ -141,7 +141,6 @@ class Hello
      */
     public function randNum()
     {
-        zm_dump(resolve('swoole_server')->worker_id);
         // 获取第一个数字类型的参数
         $num1 = ctx()->getNumArg('请输入第一个数字');
         // 获取第二个数字类型的参数
@@ -192,13 +191,7 @@ class Hello
      */
     public function onConnect(ConnectionObject $conn)
     {
-        zm_dump(resolve('path.base'));
-        zm_dump(resolve('path.config'));
-        zm_dump(resolve('app')::$server->worker_id);
         Console::info('机器人 ' . $conn->getOption('connect_id') . ' 已连接！');
-        container()->bind('cid', function () use ($conn) {
-            return resolve('app')::$server->worker_id . $conn->getOption('connect_id');
-        });
     }
 
     /**
@@ -207,7 +200,6 @@ class Hello
      */
     public function onDisconnect(ConnectionObject $conn)
     {
-        zm_dump(resolve('cid'));
         Console::info('机器人 ' . $conn->getOption('connect_id') . ' 已断开连接！');
     }
 
@@ -255,29 +247,14 @@ class Hello
     }
 
     /*
-     * @OnStart(-1)
-     */
-    #[OnStart(-1)]
-    public function initContainer()
-    {
-        $worker_container = new WorkerContainer();
-        $worker_container->bindIf('echo', function ($container, $parameters) {
-            return 'Hello, ' . $parameters[0];
-        });
-        container()->bind(ContextInterface::class, function () {
-            return ctx();
-        });
-    }
-
-    /**
-     * 容器呐
+     * 欢迎来到容器时代
      *
-     * @CQCommand("container")
+     * @param Context $context 通过依赖注入实现的
+     *
+     * @CQCommand("容器你好")
      */
-    #[CQCommand('container')]
-    public function container(): string
+    public function welcomeToContainerAge(Context $context)
     {
-        resolve(ContextInterface::class)->reply('Good'); // ctx()->reply('good')
-        return resolve('echo', ['hello']); // Hello, hello
+        $context->reply('欢迎来到容器时代');
     }
 }

--- a/src/Module/Example/Hello.php
+++ b/src/Module/Example/Hello.php
@@ -27,6 +27,7 @@ use ZM\Utils\ZMUtil;
 
 /**
  * Class Hello
+ *
  * @since 2.0
  */
 class Hello
@@ -68,6 +69,7 @@ class Hello
      */
     public function hello()
     {
+        zm_dump(resolve('swoole_server')->worker_id);
         return '你好啊，我是由炸毛框架构建的机器人！';
     }
 
@@ -134,10 +136,12 @@ class Hello
      * 问法2：从1到20的随机数
      * @CQCommand("随机数")
      * @CQCommand(pattern="*从*到*的随机数")
+     *
      * @return string
      */
     public function randNum()
     {
+        zm_dump(resolve('swoole_server')->worker_id);
         // 获取第一个数字类型的参数
         $num1 = ctx()->getNumArg('请输入第一个数字');
         // 获取第二个数字类型的参数
@@ -171,6 +175,7 @@ class Hello
     /**
      * 使用自定义参数的路由参数
      * @RequestMapping("/whoami/{name}")
+     *
      * @param  array  $param 参数
      * @return string 返回的 HTML Body
      */
@@ -182,11 +187,18 @@ class Hello
     /**
      * 在机器人连接后向终端输出信息
      * @OnOpenEvent("qq")
+     *
      * @param ConnectionObject $conn WebSocket 连接对象
      */
     public function onConnect(ConnectionObject $conn)
     {
+        zm_dump(resolve('path.base'));
+        zm_dump(resolve('path.config'));
+        zm_dump(resolve('app')::$server->worker_id);
         Console::info('机器人 ' . $conn->getOption('connect_id') . ' 已连接！');
+        container()->bind('cid', function () use ($conn) {
+            return resolve('app')::$server->worker_id . $conn->getOption('connect_id');
+        });
     }
 
     /**
@@ -195,12 +207,14 @@ class Hello
      */
     public function onDisconnect(ConnectionObject $conn)
     {
+        zm_dump(resolve('cid'));
         Console::info('机器人 ' . $conn->getOption('connect_id') . ' 已断开连接！');
     }
 
     /**
      * 阻止 Chrome 自动请求 /favicon.ico 导致的多条请求并发和干扰
      * @OnRequestEvent(rule="ctx()->getRequest()->server['request_uri'] == '/favicon.ico'",level=200)
+     *
      * @throws InterruptException
      */
     public function onRequest()

--- a/src/ZM/Container/BoundMethod.php
+++ b/src/ZM/Container/BoundMethod.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZM\Container;
+
+use Closure;
+use InvalidArgumentException;
+use ReflectionException;
+use ReflectionFunction;
+use ReflectionFunctionAbstract;
+use ReflectionMethod;
+use ReflectionParameter;
+use ZM\Utils\ReflectionUtil;
+
+class BoundMethod
+{
+    /**
+     * 调用指定闭包、类方法并注入依赖
+     *
+     * @param  Container                $container
+     * @param  callable|string          $callback
+     * @throws InvalidArgumentException
+     * @throws ReflectionException
+     * @return mixed
+     */
+    public static function call(ContainerInterface $container, $callback, array $parameters = [], string $default_method = null)
+    {
+        if (is_string($callback) && !$default_method && method_exists($callback, '__invoke')) {
+            $default_method = '__invoke';
+        }
+
+        if (is_string($callback) && $default_method) {
+            $callback = [$callback, $default_method];
+        }
+
+        if (self::isCallingNonStaticMethod($callback)) {
+            $callback[0] = $container->make($callback[0]);
+        }
+
+        if (!is_callable($callback)) {
+            throw new InvalidArgumentException('Callback is not callable.');
+        }
+
+        return call_user_func_array($callback, self::getMethodDependencies($container, $callback, $parameters));
+    }
+
+    /**
+     * 判断调用的是否为非静态方法
+     *
+     * @param  array|string        $callback
+     * @throws ReflectionException
+     */
+    protected static function isCallingNonStaticMethod($callback): bool
+    {
+        if (is_array($callback) && is_string($callback[0])) {
+            $reflection = new ReflectionMethod($callback[0], $callback[1]);
+            return !$reflection->isStatic();
+        }
+        return false;
+    }
+
+    /**
+     * Get all dependencies for a given method.
+     *
+     * @param  callable|string     $callback
+     * @throws ReflectionException
+     */
+    protected static function getMethodDependencies(ContainerInterface $container, $callback, array $parameters = []): array
+    {
+        $dependencies = [];
+
+        foreach (static::getCallReflector($callback)->getParameters() as $parameter) {
+            static::addDependencyForCallParameter($container, $parameter, $parameters, $dependencies);
+        }
+
+        return array_merge($dependencies, array_values($parameters));
+    }
+
+    /**
+     * Get the proper reflection instance for the given callback.
+     *
+     * @param  callable|string            $callback
+     * @throws \ReflectionException
+     * @return ReflectionFunctionAbstract
+     */
+    protected static function getCallReflector($callback)
+    {
+        if (is_string($callback) && str_contains($callback, '::')) {
+            $callback = explode('::', $callback);
+        } elseif (is_object($callback) && !$callback instanceof Closure) {
+            $callback = [$callback, '__invoke'];
+        }
+
+        return is_array($callback)
+            ? new ReflectionMethod($callback[0], $callback[1])
+            : new ReflectionFunction($callback);
+    }
+
+    /**
+     * Get the dependency for the given call parameter.
+     *
+     * @throws EntryResolutionException
+     */
+    protected static function addDependencyForCallParameter(
+        ContainerInterface $container,
+        ReflectionParameter $parameter,
+        array &$parameters,
+        array &$dependencies
+    ): void {
+        if (array_key_exists($param_name = $parameter->getName(), $parameters)) {
+            $dependencies[] = $parameters[$param_name];
+
+            unset($parameters[$param_name]);
+        } elseif (!is_null($class_name = ReflectionUtil::getParameterClassName($parameter))) {
+            if (array_key_exists($class_name, $parameters)) {
+                $dependencies[] = $parameters[$class_name];
+
+                unset($parameters[$class_name]);
+            } elseif ($parameter->isVariadic()) {
+                $variadic_dependencies = $container->make($class_name);
+
+                $dependencies = array_merge($dependencies, is_array($variadic_dependencies)
+                    ? $variadic_dependencies
+                    : [$variadic_dependencies]);
+            } else {
+                $dependencies[] = $container->make($class_name);
+            }
+        } elseif ($parameter->isDefaultValueAvailable()) {
+            $dependencies[] = $parameter->getDefaultValue();
+        } elseif (!array_key_exists($param_name, $parameters) && !$parameter->isOptional()) {
+            $message = "无法解析类 {$parameter->getDeclaringClass()->getName()} 的依赖 {$parameter}";
+
+            throw new EntryResolutionException($message);
+        }
+    }
+}

--- a/src/ZM/Container/Container.php
+++ b/src/ZM/Container/Container.php
@@ -15,6 +15,7 @@ class Container extends WorkerContainer
 
     public function __construct()
     {
+        parent::__construct();
         $this->parent = WorkerContainer::getInstance();
     }
 

--- a/src/ZM/Container/Container.php
+++ b/src/ZM/Container/Container.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace ZM\Container;
 
-use ReflectionException;
-
 class Container extends WorkerContainer
 {
     /**
@@ -51,7 +49,6 @@ class Container extends WorkerContainer
      * @param  string                   $abstract   类或接口名
      * @param  array                    $parameters 参数
      * @throws EntryResolutionException
-     * @throws ReflectionException
      * @return mixed                    实例
      */
     public function make(string $abstract, array $parameters = [])

--- a/src/ZM/Container/Container.php
+++ b/src/ZM/Container/Container.php
@@ -13,12 +13,9 @@ class Container extends WorkerContainer
      */
     protected $parent;
 
-    /**
-     * @param ContainerInterface $parent 父容器
-     */
-    public function __construct(ContainerInterface $parent)
+    public function __construct()
     {
-        $this->parent = $parent;
+        $this->parent = WorkerContainer::getInstance();
     }
 
     /**
@@ -46,10 +43,11 @@ class Container extends WorkerContainer
     /**
      * 获取一个绑定的实例
      *
+     * @template T
      * @param  string                   $abstract   类或接口名
      * @param  array                    $parameters 参数
      * @throws EntryResolutionException
-     * @return mixed                    实例
+     * @return T                        实例
      */
     public function make(string $abstract, array $parameters = [])
     {

--- a/src/ZM/Container/Container.php
+++ b/src/ZM/Container/Container.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZM\Container;
+
+use ReflectionException;
+
+class Container extends WorkerContainer
+{
+    /**
+     * 父容器
+     *
+     * @var ContainerInterface
+     */
+    protected $parent;
+
+    /**
+     * @param ContainerInterface $parent 父容器
+     */
+    public function __construct(ContainerInterface $parent)
+    {
+        $this->parent = $parent;
+    }
+
+    /**
+     * 获取父容器
+     */
+    public function getParent(): ContainerInterface
+    {
+        return $this->parent;
+    }
+
+    /**
+     * Returns true if the container can return an entry for the given identifier.
+     * Returns false otherwise.
+     *
+     * `has($id)` returning true does not mean that `get($id)` will not throw an exception.
+     * It does however mean that `get($id)` will not throw a `NotFoundExceptionInterface`.
+     *
+     * @param string $id identifier of the entry to look for
+     */
+    public function has(string $id): bool
+    {
+        return $this->bound($id) || $this->parent->has($id);
+    }
+
+    /**
+     * 获取一个绑定的实例
+     *
+     * @param  string                   $abstract   类或接口名
+     * @param  array                    $parameters 参数
+     * @throws EntryResolutionException
+     * @throws ReflectionException
+     * @return mixed                    实例
+     */
+    public function make(string $abstract, array $parameters = [])
+    {
+        if (isset($this->shared[$abstract])) {
+            return $this->shared[$abstract];
+        }
+
+        // 此类没有，父类有，则从父类中获取
+        if (!$this->bound($abstract) && $this->parent->bound($abstract)) {
+            return $this->parent->make($abstract, $parameters);
+        }
+
+        return parent::make($abstract, $parameters);
+    }
+
+    /**
+     * 清除所有绑定和实例
+     */
+    public function flush(): void
+    {
+        parent::flush();
+        $this->parent->flush();
+    }
+}

--- a/src/ZM/Container/Container.php
+++ b/src/ZM/Container/Container.php
@@ -44,10 +44,10 @@ class Container extends WorkerContainer
      * 获取一个绑定的实例
      *
      * @template T
-     * @param  string                   $abstract   类或接口名
+     * @param  class-string<T>          $abstract   类或接口名
      * @param  array                    $parameters 参数
      * @throws EntryResolutionException
-     * @return T                        实例
+     * @return Closure|mixed|T          实例
      */
     public function make(string $abstract, array $parameters = [])
     {

--- a/src/ZM/Container/ContainerInterface.php
+++ b/src/ZM/Container/ContainerInterface.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZM\Container;
+
+use Closure;
+use Psr\Container\ContainerInterface as PsrContainerInterface;
+
+/**
+ * Interface ContainerInterface
+ *
+ * 从 Illuminate WorkerContainer 简化而来，兼容 PSR-11
+ */
+interface ContainerInterface extends PsrContainerInterface
+{
+    /**
+     * 判断对应的类或接口是否已经注册
+     *
+     * @param string $abstract 类或接口名
+     */
+    public function bound(string $abstract): bool;
+
+    /**
+     * 注册一个类别名
+     *
+     * @param string $abstract 类或接口名
+     * @param string $alias    别名
+     */
+    public function alias(string $abstract, string $alias): void;
+
+    /**
+     * 注册绑定
+     *
+     * @param string              $abstract 类或接口名
+     * @param null|Closure|string $concrete 返回类实例的闭包，或是类名
+     * @param bool                $shared   是否共享
+     */
+    public function bind(string $abstract, $concrete = null, bool $shared = false): void;
+
+    /**
+     * 注册绑定
+     *
+     * 在已经绑定时不会重复注册
+     *
+     * @param string              $abstract 类或接口名
+     * @param null|Closure|string $concrete 返回类实例的闭包，或是类名
+     * @param bool                $shared   是否共享
+     */
+    public function bindIf(string $abstract, $concrete = null, bool $shared = false): void;
+
+    /**
+     * 注册一个单例绑定
+     *
+     * @param string              $abstract 类或接口名
+     * @param null|Closure|string $concrete 返回类实例的闭包，或是类名
+     */
+    public function singleton(string $abstract, $concrete = null): void;
+
+    /**
+     * 注册一个单例绑定
+     *
+     * 在已经绑定时不会重复注册
+     *
+     * @param string              $abstract 类或接口名
+     * @param null|Closure|string $concrete 返回类实例的闭包，或是类名
+     */
+    public function singletonIf(string $abstract, $concrete = null): void;
+
+    /**
+     * 注册一个已有的实例，效果等同于单例绑定
+     *
+     * @param  string $abstract 类或接口名
+     * @param  mixed  $instance 实例
+     * @return mixed
+     */
+    public function instance(string $abstract, $instance);
+
+    /**
+     * 获取一个解析对应类实例的闭包
+     *
+     * @param string $abstract 类或接口名
+     */
+    public function factory(string $abstract): Closure;
+
+    /**
+     * 清除所有绑定和实例
+     */
+    public function flush(): void;
+
+    /**
+     * 获取一个绑定的实例
+     *
+     * @param  string $abstract   类或接口名
+     * @param  array  $parameters 参数
+     * @return mixed  实例
+     */
+    public function make(string $abstract, array $parameters = []);
+
+    /**
+     * 调用对应的方法，并自动注入依赖
+     *
+     * @param  callable $callback   对应的方法
+     * @param  array    $parameters 参数
+     * @return mixed
+     */
+    public function call(callable $callback, array $parameters = []);
+}

--- a/src/ZM/Container/ContainerInterface.php
+++ b/src/ZM/Container/ContainerInterface.php
@@ -91,9 +91,10 @@ interface ContainerInterface extends PsrContainerInterface
     /**
      * 获取一个绑定的实例
      *
+     * @template T
      * @param  string $abstract   类或接口名
      * @param  array  $parameters 参数
-     * @return mixed  实例
+     * @return T      实例
      */
     public function make(string $abstract, array $parameters = []);
 

--- a/src/ZM/Container/ContainerInterface.php
+++ b/src/ZM/Container/ContainerInterface.php
@@ -92,9 +92,9 @@ interface ContainerInterface extends PsrContainerInterface
      * 获取一个绑定的实例
      *
      * @template T
-     * @param  string $abstract   类或接口名
-     * @param  array  $parameters 参数
-     * @return T      实例
+     * @param  class-string<T> $abstract   类或接口名
+     * @param  array           $parameters 参数
+     * @return Closure|mixed|T 实例
      */
     public function make(string $abstract, array $parameters = []);
 

--- a/src/ZM/Container/ContainerInterface.php
+++ b/src/ZM/Container/ContainerInterface.php
@@ -101,9 +101,10 @@ interface ContainerInterface extends PsrContainerInterface
     /**
      * 调用对应的方法，并自动注入依赖
      *
-     * @param  callable $callback   对应的方法
-     * @param  array    $parameters 参数
+     * @param  callable    $callback       对应的方法
+     * @param  array       $parameters     参数
+     * @param  null|string $default_method 默认方法
      * @return mixed
      */
-    public function call(callable $callback, array $parameters = []);
+    public function call(callable $callback, array $parameters = [], string $default_method = null);
 }

--- a/src/ZM/Container/EntryNotFoundException.php
+++ b/src/ZM/Container/EntryNotFoundException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZM\Container;
+
+use Exception;
+use Psr\Container\NotFoundExceptionInterface;
+
+class EntryNotFoundException extends Exception implements NotFoundExceptionInterface
+{
+}

--- a/src/ZM/Container/EntryResolutionException.php
+++ b/src/ZM/Container/EntryResolutionException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZM\Container;
+
+use Exception;
+use Psr\Container\ContainerExceptionInterface;
+
+class EntryResolutionException extends Exception implements ContainerExceptionInterface
+{
+}

--- a/src/ZM/Container/WorkerContainer.php
+++ b/src/ZM/Container/WorkerContainer.php
@@ -210,10 +210,11 @@ class WorkerContainer implements ContainerInterface
     /**
      * 获取一个绑定的实例
      *
+     * @template T
      * @param  string                   $abstract   类或接口名
      * @param  array                    $parameters 参数
      * @throws EntryResolutionException
-     * @return mixed                    实例
+     * @return T                        实例
      */
     public function make(string $abstract, array $parameters = [])
     {

--- a/src/ZM/Container/WorkerContainer.php
+++ b/src/ZM/Container/WorkerContainer.php
@@ -1,0 +1,624 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZM\Container;
+
+use Closure;
+use Exception;
+use InvalidArgumentException;
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\NotFoundExceptionInterface;
+use ReflectionClass;
+use ReflectionException;
+use ReflectionNamedType;
+use ReflectionParameter;
+
+class WorkerContainer implements ContainerInterface
+{
+    /**
+     * @var array
+     */
+    protected $shared = [];
+
+    /**
+     * @var array[]
+     */
+    protected $buildStack = [];
+
+    /**
+     * @var array[]
+     */
+    protected $with = [];
+
+    /**
+     * @var array[]
+     */
+    private static $bindings = [];
+
+    /**
+     * @var object[]
+     */
+    private static $instances = [];
+
+    /**
+     * @var string[]
+     */
+    private static $aliases = [];
+
+    /**
+     * @var Closure[][]
+     */
+    private static $extenders = [];
+
+    /**
+     * 判断对应的类或接口是否已经注册
+     *
+     * @param string $abstract 类或接口名
+     */
+    public function bound(string $abstract): bool
+    {
+        return array_key_exists($abstract, self::$bindings)
+            || array_key_exists($abstract, self::$instances)
+            || array_key_exists($abstract, $this->shared)
+            || $this->isAlias($abstract);
+    }
+
+    /**
+     * 获取类别名（如存在）
+     *
+     * @param  string $abstract 类或接口名
+     * @return string 别名，不存在时返回传入的类或接口名
+     */
+    public function getAlias(string $abstract): string
+    {
+        if (!isset(self::$aliases[$abstract])) {
+            return $abstract;
+        }
+
+        return $this->getAlias(self::$aliases[$abstract]);
+    }
+
+    /**
+     * 注册一个类别名
+     *
+     * @param string $abstract 类或接口名
+     * @param string $alias    别名
+     */
+    public function alias(string $abstract, string $alias): void
+    {
+        if ($alias === $abstract) {
+            throw new InvalidArgumentException("[{$abstract}] is same as [{$alias}]");
+        }
+
+        self::$aliases[$alias] = $abstract;
+    }
+
+    /**
+     * 注册绑定
+     *
+     * @param string              $abstract 类或接口名
+     * @param null|Closure|string $concrete 返回类实例的闭包，或是类名
+     * @param bool                $shared   是否共享
+     */
+    public function bind(string $abstract, $concrete = null, bool $shared = false): void
+    {
+        $this->dropStaleInstances($abstract);
+
+        // 如果没有提供闭包，则默认为自动解析类名
+        if (is_null($concrete)) {
+            $concrete = $abstract;
+        }
+
+        // 如果不是闭包，则认为是类名，此时将其包装在一个闭包中，以方便后续处理
+        if (!$concrete instanceof Closure) {
+            $concrete = $this->getClosure($abstract, $concrete);
+        }
+
+        self::$bindings[$abstract] = compact('concrete', 'shared');
+    }
+
+    /**
+     * 注册绑定
+     *
+     * 在已经绑定时不会重复注册
+     *
+     * @param string              $abstract 类或接口名
+     * @param null|Closure|string $concrete 返回类实例的闭包，或是类名
+     * @param bool                $shared   是否共享
+     */
+    public function bindIf(string $abstract, $concrete = null, bool $shared = false): void
+    {
+        if (!$this->bound($abstract)) {
+            $this->bind($abstract, $concrete, $shared);
+        }
+    }
+
+    /**
+     * 注册一个单例绑定
+     *
+     * @param string              $abstract 类或接口名
+     * @param null|Closure|string $concrete 返回类实例的闭包，或是类名
+     */
+    public function singleton(string $abstract, $concrete = null): void
+    {
+        $this->bind($abstract, $concrete, true);
+    }
+
+    /**
+     * 注册一个单例绑定
+     *
+     * 在已经绑定时不会重复注册
+     *
+     * @param string              $abstract 类或接口名
+     * @param null|Closure|string $concrete 返回类实例的闭包，或是类名
+     */
+    public function singletonIf(string $abstract, $concrete = null): void
+    {
+        if (!$this->bound($abstract)) {
+            $this->singleton($abstract, $concrete);
+        }
+    }
+
+    /**
+     * 注册一个已有的实例，效果等同于单例绑定
+     *
+     * @param  string $abstract 类或接口名
+     * @param  mixed  $instance 实例
+     * @return mixed
+     */
+    public function instance(string $abstract, $instance)
+    {
+        if (isset(self::$instances[$abstract])) {
+            return self::$instances[$abstract];
+        }
+
+        self::$instances[$abstract] = $instance;
+
+        return $instance;
+    }
+
+    /**
+     * 获取一个解析对应类实例的闭包
+     *
+     * @param string $abstract 类或接口名
+     */
+    public function factory(string $abstract): Closure
+    {
+        return function () use ($abstract) {
+            return $this->make($abstract);
+        };
+    }
+
+    /**
+     * 清除所有绑定和实例
+     */
+    public function flush(): void
+    {
+        self::$aliases = [];
+        self::$bindings = [];
+        self::$instances = [];
+
+        $this->shared = [];
+        $this->buildStack = [];
+        $this->with = [];
+    }
+
+    /**
+     * 获取一个绑定的实例
+     *
+     * @param  string                   $abstract   类或接口名
+     * @param  array                    $parameters 参数
+     * @throws EntryResolutionException
+     * @throws ReflectionException
+     * @return mixed                    实例
+     */
+    public function make(string $abstract, array $parameters = [])
+    {
+        $abstract = $this->getAlias($abstract);
+
+        $needs_contextual_build = !empty($parameters);
+
+        if (isset($this->shared[$abstract])) {
+            return $this->shared[$abstract];
+        }
+
+        // 如果已经存在在实例池中（通常意味着单例绑定），则直接返回该实例
+        if (isset(self::$instances[$abstract]) && !$needs_contextual_build) {
+            return self::$instances[$abstract];
+        }
+
+        $this->with[] = $parameters;
+
+        $concrete = $this->getConcrete($abstract);
+
+        // 构造该类的实例，并递归解析所有依赖
+        if ($this->isBuildable($concrete, $abstract)) {
+            $object = $this->build($concrete);
+        } else {
+            $object = $this->make($concrete);
+        }
+
+        // 如果该类存在扩展器（装饰器），则逐个应用到实例
+        foreach ($this->getExtenders($abstract) as $extender) {
+            $object = $extender($object, $this);
+        }
+
+        // 如果该类被注册为单例，则需要将其存放在实例池中，方便后续取用同一实例
+        if (!$needs_contextual_build && $this->isShared($abstract)) {
+            $this->shared[$abstract] = $object;
+        }
+
+        // 弹出本次构造的覆盖参数
+        array_pop($this->with);
+
+        return $object;
+    }
+
+    /**
+     * 实例化具体的类实例
+     *
+     * @param  Closure|string           $concrete 类名或对应的闭包
+     * @throws EntryResolutionException
+     * @throws ReflectionException
+     * @return mixed
+     */
+    public function build($concrete)
+    {
+        // 如果传入的是闭包，则直接执行并返回
+        if ($concrete instanceof Closure) {
+            return $concrete($this, $this->getLastParameterOverride());
+        }
+
+        try {
+            $reflection = new ReflectionClass($concrete);
+        } catch (ReflectionException $e) {
+            throw new EntryResolutionException("指定的类 {$concrete} 不存在");
+        }
+
+        if (!$reflection->isInstantiable()) {
+            $this->notInstantiable($concrete);
+        }
+
+        $this->buildStack[] = $concrete;
+
+        $constructor = $reflection->getConstructor();
+
+        // 如果不存在构造函数，则代表不需要进一步解析，直接实例化即可
+        if (is_null($constructor)) {
+            array_pop($this->buildStack);
+            return new $concrete();
+        }
+
+        $dependencies = $constructor->getParameters();
+
+        // 获取所有依赖的实例
+        $instances = $this->resolveDependencies($dependencies);
+
+        array_pop($this->buildStack);
+
+        return $reflection->newInstanceArgs($instances);
+    }
+
+    /**
+     * 调用对应的方法，并自动注入依赖
+     *
+     * @param  callable $callback   对应的方法
+     * @param  array    $parameters 参数
+     * @return mixed
+     */
+    public function call(callable $callback, array $parameters = [])
+    {
+        // TODO: Implement call() method.
+    }
+
+    /**
+     * Finds an entry of the container by its identifier and returns it.
+     *
+     * @param string $id identifier of the entry to look for
+     *
+     * @throws NotFoundExceptionInterface  no entry was found for **this** identifier
+     * @throws ContainerExceptionInterface error while retrieving the entry
+     *
+     * @return mixed entry
+     */
+    public function get(string $id)
+    {
+        try {
+            return $this->make($id);
+        } catch (Exception $e) {
+            if ($this->has($id)) {
+                throw new EntryResolutionException('', 0, $e);
+            }
+
+            throw new EntryNotFoundException('', 0, $e);
+        }
+    }
+
+    /**
+     * Returns true if the container can return an entry for the given identifier.
+     * Returns false otherwise.
+     *
+     * `has($id)` returning true does not mean that `get($id)` will not throw an exception.
+     * It does however mean that `get($id)` will not throw a `NotFoundExceptionInterface`.
+     *
+     * @param string $id identifier of the entry to look for
+     */
+    public function has(string $id): bool
+    {
+        return $this->bound($id);
+    }
+
+    /**
+     * 扩展一个类或接口
+     *
+     * @param string  $abstract 类或接口名
+     * @param Closure $closure  扩展闭包
+     */
+    public function extend(string $abstract, Closure $closure): void
+    {
+        $abstract = $this->getAlias($abstract);
+
+        // 如果该类已经被解析过，则直接将扩展器应用到该类的实例上
+        // 否则，将扩展器存入扩展器池，等待解析
+        if (isset(self::$instances[$abstract])) {
+            self::$instances[$abstract] = $closure(self::$instances[$abstract], $this);
+        } else {
+            self::$extenders[$abstract][] = $closure;
+        }
+    }
+
+    /**
+     * 获取对应类型的所有扩展器
+     *
+     * @param  string    $abstract 类或接口名
+     * @return Closure[]
+     */
+    protected function getExtenders(string $abstract): array
+    {
+        $abstract = $this->getAlias($abstract);
+
+        return self::$extenders[$abstract] ?? [];
+    }
+
+    /**
+     * 判断传入的是否为别名
+     */
+    protected function isAlias(string $name): bool
+    {
+        return array_key_exists($name, self::$aliases);
+    }
+
+    /**
+     * 抛弃所有过时的实例和别名
+     *
+     * @param string $abstract 类或接口名
+     */
+    protected function dropStaleInstances(string $abstract): void
+    {
+        unset(
+            self::$instances[$abstract],
+            self::$aliases[$abstract],
+            $this->shared[$abstract]
+        );
+    }
+
+    /**
+     * 获取一个解析对应类的闭包
+     *
+     * @param string $abstract 类或接口名
+     * @param string $concrete 实际类名
+     */
+    protected function getClosure(string $abstract, string $concrete): Closure
+    {
+        return static function ($container, $parameters = []) use ($abstract, $concrete) {
+            $method = $abstract === $concrete ? 'build' : 'make';
+
+            return $container->{$method}($concrete, $parameters);
+        };
+    }
+
+    /**
+     * 获取最后一次的覆盖参数
+     */
+    protected function getLastParameterOverride(): array
+    {
+        return $this->with[count($this->with) - 1] ?? [];
+    }
+
+    /**
+     * 抛出实例化异常
+     *
+     * @throws EntryResolutionException
+     */
+    protected function notInstantiable(string $concrete, string $reason = ''): void
+    {
+        if (!empty($this->buildStack)) {
+            $previous = implode(', ', $this->buildStack);
+            $message = "类 {$concrete} 无法实例化，其被 {$previous} 依赖";
+        } else {
+            $message = "类 {$concrete} 无法实例化";
+        }
+
+        throw new EntryResolutionException("{$message}：{$reason}");
+    }
+
+    /**
+     * 解析依赖
+     *
+     * @param  ReflectionParameter[]    $dependencies
+     * @throws EntryResolutionException
+     * @throws ReflectionException
+     */
+    protected function resolveDependencies(array $dependencies): array
+    {
+        $results = [];
+
+        foreach ($dependencies as $dependency) {
+            // 如果此依赖存在覆盖参数，则使用覆盖参数
+            // 否则，将尝试解析参数
+            if ($this->hasParameterOverride($dependency)) {
+                $results[] = $this->getParameterOverride($dependency);
+                continue;
+            }
+
+            // 如果存在临时注入的依赖，则使用临时注入的依赖
+            if ($this->hasParameterTypeOverride($dependency)) {
+                $results[] = $this->getParameterTypeOverride($dependency);
+                continue;
+            }
+
+            // 获取参数类型
+            $type = $dependency->getType();
+            // 没有声明类型或为基本类型
+            if (!$type instanceof ReflectionNamedType || $type->isBuiltin()) {
+                $class_name = null;
+            } else {
+                // 获取类名
+                $class_name = $type->getName();
+                // 如果存在父类
+                if (!is_null($class = $dependency->getDeclaringClass())) {
+                    if ($class_name === 'self') {
+                        $class_name = $class->getName();
+                    } elseif ($class_name === 'parent') {
+                        $class_name = $class->getParentClass()->getName();
+                    }
+                }
+            }
+
+            // 如果类名为空，则代表此依赖是基本类型，且无法对其进行依赖解析
+            $results[] = is_null($class_name)
+                ? $this->resolvePrimitive($dependency)
+                : $this->resolveClass($dependency);
+        }
+
+        return $results;
+    }
+
+    /**
+     * 判断传入的参数是否存在覆盖参数
+     */
+    protected function hasParameterOverride(ReflectionParameter $parameter): bool
+    {
+        return array_key_exists($parameter->name, $this->getLastParameterOverride());
+    }
+
+    /**
+     * 获取覆盖参数
+     *
+     * @return mixed
+     */
+    protected function getParameterOverride(ReflectionParameter $parameter)
+    {
+        return $this->getLastParameterOverride()[$parameter->name];
+    }
+
+    /**
+     * 判断传入的参数是否存在临时注入的参数
+     */
+    protected function hasParameterTypeOverride(ReflectionParameter $parameter): bool
+    {
+        if (!$parameter->hasType()) {
+            return false;
+        }
+
+        $type = $parameter->getType();
+
+        if (!$type instanceof ReflectionNamedType || $type->isBuiltin()) {
+            return false;
+        }
+
+        return array_key_exists($type->getName(), $this->getLastParameterOverride());
+    }
+
+    /**
+     * 获取临时注入的参数
+     *
+     * @return mixed
+     */
+    protected function getParameterTypeOverride(ReflectionParameter $parameter)
+    {
+        $type = $parameter->getType();
+
+        if (!$type instanceof ReflectionNamedType) {
+            return [];
+        }
+
+        return $this->getLastParameterOverride()[$type->getName()];
+    }
+
+    /**
+     * 解析基本类型
+     *
+     * @throws EntryResolutionException 如参数不存在默认值，则抛出异常
+     * @return mixed                    对应类型的默认值
+     */
+    protected function resolvePrimitive(ReflectionParameter $parameter)
+    {
+        if ($parameter->isDefaultValueAvailable()) {
+            return $parameter->getDefaultValue();
+        }
+
+        throw new EntryResolutionException("无法解析类 {$parameter->getDeclaringClass()->getName()} 的参数 {$parameter}");
+    }
+
+    /**
+     * 解析类
+     *
+     * @throws EntryResolutionException 如果无法解析类，则抛出异常
+     * @throws ReflectionException      实际上不会抛出，请无视
+     * @return mixed
+     */
+    protected function resolveClass(ReflectionParameter $parameter)
+    {
+        try {
+            // 尝试解析
+            return $this->make($parameter->getClass()->name);
+        } catch (EntryResolutionException $e) {
+            // 如果参数是可选的，则返回默认值
+            if ($parameter->isOptional()) {
+                return $parameter->getDefaultValue();
+            }
+
+            throw $e;
+        }
+    }
+
+    /**
+     * 获取类名的实际类型
+     *
+     * @param  string         $abstract 类或接口名
+     * @return Closure|string
+     */
+    protected function getConcrete(string $abstract)
+    {
+        if (isset(self::$bindings[$abstract])) {
+            return self::$bindings[$abstract]['concrete'];
+        }
+
+        return $abstract;
+    }
+
+    /**
+     * 判断传入的实际类型是否可以构造
+     *
+     * @param mixed  $concrete 实际类型
+     * @param string $abstract 类或接口名
+     */
+    protected function isBuildable($concrete, string $abstract): bool
+    {
+        return $concrete === $abstract || $concrete instanceof Closure;
+    }
+
+    /**
+     * 判断传入的类型是否为共享实例
+     *
+     * @param string $abstract 类或接口名
+     */
+    protected function isShared(string $abstract): bool
+    {
+        return isset($this->instances[$abstract])
+            || (isset($this->bindings[$abstract]['shared'])
+                && $this->bindings[$abstract]['shared'] === true);
+    }
+}

--- a/src/ZM/Container/WorkerContainer.php
+++ b/src/ZM/Container/WorkerContainer.php
@@ -334,7 +334,7 @@ class WorkerContainer implements ContainerInterface
         try {
             $reflection = new ReflectionClass($concrete);
         } catch (ReflectionException $e) {
-            throw new EntryResolutionException("指定的类 {$concrete} 不存在");
+            throw new EntryResolutionException("指定的类 {$concrete} 不存在", 0, $e);
         }
 
         if (!$reflection->isInstantiable()) {

--- a/src/ZM/Container/WorkerContainer.php
+++ b/src/ZM/Container/WorkerContainer.php
@@ -211,10 +211,10 @@ class WorkerContainer implements ContainerInterface
      * 获取一个绑定的实例
      *
      * @template T
-     * @param  string                   $abstract   类或接口名
+     * @param  class-string<T>          $abstract   类或接口名
      * @param  array                    $parameters 参数
      * @throws EntryResolutionException
-     * @return T                        实例
+     * @return Closure|mixed|T          实例
      */
     public function make(string $abstract, array $parameters = [])
     {

--- a/src/ZM/Event/EventDispatcher.php
+++ b/src/ZM/Event/EventDispatcher.php
@@ -188,7 +188,9 @@ class EventDispatcher
         if (isset(EventManager::$middleware_map[$q_c][$q_f])) {
             $middlewares = EventManager::$middleware_map[$q_c][$q_f];
             if ($this->log) {
-                Console::verbose("[事件分发{$this->eid}] " . $q_c . '::' . $q_f . ' 方法还绑定了 Middleware：' . implode(', ', array_map(function ($x) { return $x->middleware; }, $middlewares)));
+                Console::verbose("[事件分发{$this->eid}] " . $q_c . '::' . $q_f . ' 方法还绑定了 Middleware：' . implode(', ', array_map(function ($x) {
+                    return $x->middleware;
+                }, $middlewares)));
             }
             $before_result = true;
             $r = [];
@@ -231,7 +233,7 @@ class EventDispatcher
                     if ($this->log) {
                         Console::verbose("[事件分发{$this->eid}] 正在执行方法 " . $q_c . '::' . $q_f . ' ...');
                     }
-                    $this->store = $q_o->{$q_f}(...$params);
+                    $this->store = container()->call([$q_o, $q_f], $params);
                 } catch (Exception $e) {
                     if ($e instanceof InterruptException) {
                         if ($this->log) {
@@ -283,7 +285,7 @@ class EventDispatcher
         if ($this->log) {
             Console::verbose("[事件分发{$this->eid}] 正在执行方法 " . $q_c . '::' . $q_f . ' ...');
         }
-        $this->store = $q_o->{$q_f}(...$params);
+        $this->store = container()->call([$q_o, $q_f], $params);
         $this->status = self::STATUS_NORMAL;
         return true;
     }

--- a/src/ZM/Event/SwooleEvent/OnWorkerStart.php
+++ b/src/ZM/Event/SwooleEvent/OnWorkerStart.php
@@ -20,6 +20,7 @@ use ZM\Annotation\Swoole\OnStart;
 use ZM\Annotation\Swoole\SwooleHandler;
 use ZM\Config\ZMConfig;
 use ZM\Console\Console;
+use ZM\Container\WorkerContainer;
 use ZM\Context\Context;
 use ZM\Context\ContextInterface;
 use ZM\DB\DB;
@@ -52,6 +53,13 @@ class OnWorkerStart implements SwooleEvent
             SignalListener::signalWorker($server, $worker_id);
         }
         unset(Context::$context[Coroutine::getCid()]);
+
+        /* @noinspection PhpExpressionResultUnusedInspection */
+        new WorkerContainer();
+        if (Console::getLevel() >= 4) {
+            Console::debug(sprintf('Worker container [id=%d,cid=%d] booted', $worker_id, Coroutine::getCid()));
+        }
+
         if ($server->taskworker === false) {
             Framework::saveProcessState(ZM_PROCESS_WORKER, $server->worker_pid, ['worker_id' => $worker_id]);
             zm_atomic('_#worker_' . $worker_id)->set($server->worker_pid);
@@ -274,7 +282,7 @@ class OnWorkerStart implements SwooleEvent
                 (new PDOConfig())
                     ->withHost($real_conf['host'])
                     ->withPort($real_conf['port'])
-                // ->withUnixSocket('/tmp/mysql.sock')
+                    // ->withUnixSocket('/tmp/mysql.sock')
                     ->withDbName($real_conf['dbname'])
                     ->withCharset($real_conf['charset'])
                     ->withUsername($real_conf['username'])

--- a/src/ZM/Event/SwooleEvent/OnWorkerStart.php
+++ b/src/ZM/Event/SwooleEvent/OnWorkerStart.php
@@ -54,11 +54,7 @@ class OnWorkerStart implements SwooleEvent
         }
         unset(Context::$context[Coroutine::getCid()]);
 
-        /* @noinspection PhpExpressionResultUnusedInspection */
-        new WorkerContainer();
-        if (Console::getLevel() >= 4) {
-            Console::debug(sprintf('Worker container [id=%d,cid=%d] booted', $worker_id, Coroutine::getCid()));
-        }
+        $this->registerWorkerContainerBindings($server);
 
         if ($server->taskworker === false) {
             Framework::saveProcessState(ZM_PROCESS_WORKER, $server->worker_pid, ['worker_id' => $worker_id]);
@@ -291,5 +287,25 @@ class OnWorkerStart implements SwooleEvent
             );
             DB::initTableList($real_conf['dbname']);
         }
+    }
+
+    /**
+     * 注册进程容器绑定
+     */
+    private function registerWorkerContainerBindings(Server $server): void
+    {
+        $container = WorkerContainer::getInstance();
+        $container->setLogPrefix("[WorkerContainer#{$server->worker_id}]");
+        // 路径
+        $container->instance('path.working', DataProvider::getWorkingDir());
+        $container->instance('path.source', DataProvider::getSourceRootDir());
+        $container->alias('path.source', 'path.base');
+        $container->instance('path.config', DataProvider::getSourceRootDir() . '/config');
+        $container->instance('path.module_config', ZMConfig::get('global', 'config_dir'));
+        $container->instance('path.data', DataProvider::getDataFolder());
+        $container->instance('path.framework', DataProvider::getFrameworkRootDir());
+        // 基础
+        $container->instance('server', $server);
+        $container->instance('worker_id', $server->worker_id);
     }
 }

--- a/src/ZM/Event/SwooleEvent/OnWorkerStop.php
+++ b/src/ZM/Event/SwooleEvent/OnWorkerStop.php
@@ -8,6 +8,7 @@ use Swoole\Server;
 use ZM\Annotation\Swoole\SwooleHandler;
 use ZM\Config\ZMConfig;
 use ZM\Console\Console;
+use ZM\Container\WorkerContainer;
 use ZM\Event\SwooleEvent;
 use ZM\Framework;
 use ZM\Store\LightCache;
@@ -20,6 +21,11 @@ class OnWorkerStop implements SwooleEvent
 {
     public function onCall(Server $server, $worker_id)
     {
+        WorkerContainer::getInstance()->flush();
+        if (Console::getLevel() >= 4) {
+            Console::debug(sprintf('Worker container [id=%d] flushed', $worker_id));
+        }
+
         if ($worker_id == (ZMConfig::get('worker_cache')['worker'] ?? 0)) {
             LightCache::savePersistence();
         }

--- a/src/ZM/Event/SwooleEvent/OnWorkerStop.php
+++ b/src/ZM/Event/SwooleEvent/OnWorkerStop.php
@@ -22,9 +22,6 @@ class OnWorkerStop implements SwooleEvent
     public function onCall(Server $server, $worker_id)
     {
         WorkerContainer::getInstance()->flush();
-        if (Console::getLevel() >= 4) {
-            Console::debug(sprintf('Worker container [id=%d] flushed', $worker_id));
-        }
 
         if ($worker_id == (ZMConfig::get('worker_cache')['worker'] ?? 0)) {
             LightCache::savePersistence();

--- a/src/ZM/Framework.php
+++ b/src/ZM/Framework.php
@@ -109,7 +109,7 @@ class Framework
 
         // 确保目录存在
         DataProvider::createIfNotExists(app('path.data'));
-        DataProvider::createIfNotExists(app('path.config'));
+        DataProvider::createIfNotExists(app('path.module_config'));
         DataProvider::createIfNotExists(ZMConfig::get('global', 'crash_dir'));
 
         // 初始化连接池？
@@ -624,6 +624,7 @@ class Framework
         $this->container->instance('path.source', DataProvider::getSourceRootDir());
         $this->container->alias('path.source', 'path.base');
         $this->container->instance('path.config', DataProvider::getSourceRootDir() . '/config');
+        $this->container->instance('path.module_config', ZMConfig::get('global', 'config_dir'));
         $this->container->singleton('path.data', function () {
             return DataProvider::getDataFolder();
         });

--- a/src/ZM/Framework.php
+++ b/src/ZM/Framework.php
@@ -97,7 +97,7 @@ class Framework
         $this->registerBaseBindings();
 
         // 初始化配置
-        ZMConfig::setDirectory($this->container->get('path.config'));
+        ZMConfig::setDirectory(app('path.config'));
         ZMConfig::setEnv($args['env'] ?? '');
         if (ZMConfig::get('global') === false) {
             echo zm_internal_errcode('E00007') . 'Global config load failed: ' . ZMConfig::$last_error . "\nError path: " . DataProvider::getSourceRootDir() . "\nPlease init first!\nSee: https://github.com/zhamao-robot/zhamao-framework/issues/37\n";
@@ -624,7 +624,9 @@ class Framework
         $this->container->instance('path.source', DataProvider::getSourceRootDir());
         $this->container->alias('path.source', 'path.base');
         $this->container->instance('path.config', DataProvider::getSourceRootDir() . '/config');
-        $this->container->instance('path.module_config', ZMConfig::get('global', 'config_dir'));
+        $this->container->singleton('path.module_config', function () {
+            return ZMConfig::get('global', 'config_dir');
+        });
         $this->container->singleton('path.data', function () {
             return DataProvider::getDataFolder();
         });

--- a/src/ZM/Store/ZMBuf.php
+++ b/src/ZM/Store/ZMBuf.php
@@ -10,13 +10,39 @@ declare(strict_types=1);
 
 namespace ZM\Store;
 
+use ZM\Context\ContextInterface;
+
 class ZMBuf
 {
+    /**
+     * 注册的事件
+     *
+     * @deprecated 不再使用
+     *
+     * @var array
+     */
     public static $events = [];
 
+    /**
+     * 全局单例容器
+     *
+     * @var array
+     */
     public static $instance = [];
 
+    /**
+     * 上下文容器
+     *
+     * @var array<int, ContextInterface>
+     */
     public static $context_class = [];
 
+    /**
+     * 终端输入流？
+     *
+     * 目前等用于 STDIN
+     *
+     * @var resource
+     */
     public static $terminal;
 }

--- a/src/ZM/Utils/DataProvider.php
+++ b/src/ZM/Utils/DataProvider.php
@@ -7,6 +7,7 @@ namespace ZM\Utils;
 
 use Iterator;
 use JsonSerializable;
+use RuntimeException;
 use Traversable;
 use ZM\Config\ZMConfig;
 use ZM\Console\Console;
@@ -25,6 +26,7 @@ class DataProvider
 
     /**
      * 返回工作目录，不带最右边文件夹的斜杠（/）
+     *
      * @return false|string
      */
     public static function getWorkingDir()
@@ -34,6 +36,7 @@ class DataProvider
 
     /**
      * 获取框架所在根目录
+     *
      * @return false|string
      */
     public static function getFrameworkRootDir()
@@ -43,6 +46,7 @@ class DataProvider
 
     /**
      * 获取源码根目录，除Phar模式外均与工作目录相同
+     *
      * @return false|string
      */
     public static function getSourceRootDir()
@@ -52,6 +56,7 @@ class DataProvider
 
     /**
      * 获取框架反代链接
+     *
      * @return null|array|false|mixed
      */
     public static function getFrameworkLink()
@@ -61,6 +66,7 @@ class DataProvider
 
     /**
      * 获取zm_data数据目录，如果二级目录不为空，则自动创建目录并返回
+     *
      * @return null|array|false|mixed|string
      */
     public static function getDataFolder(string $second = '')
@@ -79,6 +85,7 @@ class DataProvider
 
     /**
      * 将变量保存在zm_data下的数据目录，传入数组
+     *
      * @param  string                                                 $filename   文件名
      * @param  array|int|Iterator|JsonSerializable|string|Traversable $file_array 文件内容数组
      * @return false|int                                              返回文件大小或false
@@ -104,6 +111,7 @@ class DataProvider
 
     /**
      * 从json加载变量到内存
+     *
      * @param  string     $filename 文件名
      * @return null|mixed 返回文件内容数据或null
      */
@@ -118,6 +126,7 @@ class DataProvider
 
     /**
      * 递归或非递归扫描目录，可返回相对目录的文件列表或绝对目录的文件列表
+     *
      * @param  string      $dir       目录
      * @param  bool        $recursive 是否递归扫描子目录
      * @param  bool|string $relative  是否返回相对目录，如果为true则返回相对目录，如果为false则返回绝对目录
@@ -161,6 +170,7 @@ class DataProvider
 
     /**
      * 检查路径是否为相对路径（根据第一个字符是否为"/"来判断）
+     *
      * @param  string $path 路径
      * @return bool   返回结果
      * @since 2.5
@@ -168,5 +178,17 @@ class DataProvider
     public static function isRelativePath(string $path): bool
     {
         return strlen($path) > 0 && $path[0] !== '/';
+    }
+
+    /**
+     * 创建目录（如果不存在）
+     *
+     * @param string $path 目录路径
+     */
+    public static function createIfNotExists(string $path): void
+    {
+        if (!is_dir($path) && !mkdir($path, 0777, true) && !is_dir($path)) {
+            throw new RuntimeException(sprintf('无法建立目录：%s', $path));
+        }
     }
 }

--- a/src/ZM/Utils/ReflectionUtil.php
+++ b/src/ZM/Utils/ReflectionUtil.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZM\Utils;
+
+use ReflectionNamedType;
+use ReflectionParameter;
+
+class ReflectionUtil
+{
+    /**
+     * 获取参数的类名（如有）
+     *
+     * @param  ReflectionParameter $parameter 参数
+     * @return null|string         类名，如果参数不是类，返回 null
+     */
+    public static function getParameterClassName(ReflectionParameter $parameter): ?string
+    {
+        // 获取参数类型
+        $type = $parameter->getType();
+        // 没有声明类型或为基本类型
+        if (!$type instanceof ReflectionNamedType || $type->isBuiltin()) {
+            return null;
+        }
+
+        // 获取类名
+        $class_name = $type->getName();
+
+        // 如果存在父类
+        if (!is_null($class = $parameter->getDeclaringClass())) {
+            if ($class_name === 'self') {
+                return $class->getName();
+            }
+
+            if ($class_name === 'parent' && $parent = $class->getParentClass()) {
+                return $parent->getName();
+            }
+        }
+
+        return $class_name;
+    }
+}

--- a/src/ZM/Utils/ReflectionUtil.php
+++ b/src/ZM/Utils/ReflectionUtil.php
@@ -40,4 +40,40 @@ class ReflectionUtil
 
         return $class_name;
     }
+
+    /**
+     * 将传入变量转换为字符串
+     *
+     * @param mixed $var
+     */
+    public static function variableToString($var): string
+    {
+        switch (true) {
+            case is_callable($var):
+                if (is_array($var)) {
+                    if (is_object($var[0])) {
+                        return get_class($var[0]) . '@' . $var[1];
+                    }
+                    return $var[0] . '::' . $var[1];
+                }
+                return 'closure';
+            case is_string($var):
+                return $var;
+            case is_array($var):
+                return 'array' . json_encode($var);
+            case is_object($var):
+                return get_class($var);
+            case is_resource($var):
+                return 'resource' . get_resource_type($var);
+            case is_null($var):
+                return 'null';
+            case is_bool($var):
+                return $var ? 'true' : 'false';
+            case is_float($var):
+            case is_int($var):
+                return (string) $var;
+            default:
+                return 'unknown';
+        }
+    }
 }

--- a/src/ZM/Utils/SingletonTrait.php
+++ b/src/ZM/Utils/SingletonTrait.php
@@ -1,30 +1,34 @@
 <?php
 
-/** @noinspection PhpUnused */
-
 declare(strict_types=1);
 
 namespace ZM\Utils;
 
 trait SingletonTrait
 {
+    /**
+     * @deprecated 将会于未来版本移除
+     *
+     * @var array
+     */
     protected static $cached = [];
 
     /**
-     * @var self
+     * @var null|static
      */
-    private static $instance;
+    protected static $instance;
 
     /**
-     * @return self
-     * @noinspection PhpMissingReturnTypeInspection
+     * 获取类实例
+     *
+     * @return static
      */
     public static function getInstance()
     {
-        if (self::$instance === null) {
-            self::$instance = new self();
+        if (is_null(static::$instance)) {
+            static::$instance = new static();
         }
 
-        return self::$instance;
+        return static::$instance;
     }
 }

--- a/src/ZM/global_functions.php
+++ b/src/ZM/global_functions.php
@@ -223,7 +223,7 @@ function get_annotations(): array
  */
 function set_coroutine_params(array $params): void
 {
-    $cid = Co::getCid();
+    $cid = co::getCid();
     if ($cid === -1) {
         exit(zm_internal_errcode('E00061') . 'Cannot set coroutine params at none coroutine mode.');
     }
@@ -233,7 +233,7 @@ function set_coroutine_params(array $params): void
         Context::$context[$cid] = $params;
     }
     foreach (Context::$context as $c => $v) {
-        if (!Co::exists($c)) {
+        if (!co::exists($c)) {
             unset(Context::$context[$c], ZMBuf::$context_class[$c]);
         }
     }
@@ -252,13 +252,13 @@ function context(): ContextInterface
  */
 function ctx(): ContextInterface
 {
-    $cid = Co::getCid();
+    $cid = co::getCid();
     $c_class = ZMConfig::get('global', 'context_class');
     if (isset(Context::$context[$cid])) {
         return ZMBuf::$context_class[$cid] ?? (ZMBuf::$context_class[$cid] = new $c_class($cid));
     }
     Console::debug("未找到当前协程的上下文({$cid})，正在找父进程的上下文");
-    while (($parent_cid = Co::getPcid($cid)) !== -1) {
+    while (($parent_cid = co::getPcid($cid)) !== -1) {
         $cid = $parent_cid;
         if (isset(Context::$context[$cid])) {
             return ZMBuf::$context_class[$cid] ?? (ZMBuf::$context_class[$cid] = new $c_class($cid));
@@ -320,7 +320,7 @@ function zm_exec(string $command): array
  */
 function zm_cid(): int
 {
-    return Co::getCid();
+    return co::getCid();
 }
 
 /**
@@ -330,7 +330,7 @@ function zm_cid(): int
  */
 function zm_yield()
 {
-    Co::yield();
+    co::yield();
 }
 
 /**
@@ -340,7 +340,7 @@ function zm_yield()
  */
 function zm_resume(int $cid)
 {
-    Co::resume($cid);
+    co::resume($cid);
 }
 
 /**

--- a/src/ZM/global_functions.php
+++ b/src/ZM/global_functions.php
@@ -628,7 +628,6 @@ function zm_internal_errcode($code): string
 }
 
 /**
-<<<<<<< HEAD
  * 将可能为数组的参数转换为字符串
  *
  * 如传入字符串则为原样返回

--- a/src/ZM/global_functions.php
+++ b/src/ZM/global_functions.php
@@ -655,7 +655,9 @@ function container(): ContainerInterface
 /**
  * 解析类实例（使用容器）
  *
- * @return mixed
+ * @template T
+ * @param  string<T> $abstract
+ * @return T
  */
 function resolve(string $abstract, array $parameters = [])
 {
@@ -665,8 +667,9 @@ function resolve(string $abstract, array $parameters = [])
 /**
  * 获取容器实例
  *
- * @param  null|string              $abstract 类或接口名，不传入则返回容器实例
- * @return ContainerInterface|mixed
+ * @template T
+ * @param  null|string<T>       $abstract
+ * @return ContainerInterface|T
  */
 function app(string $abstract = null, array $parameters = [])
 {

--- a/src/ZM/global_functions.php
+++ b/src/ZM/global_functions.php
@@ -241,8 +241,6 @@ function set_coroutine_params(array $params): void
 
 /**
  * 获取当前上下文
- *
- * @throws ZMKnownException
  */
 function context(): ContextInterface
 {
@@ -251,8 +249,6 @@ function context(): ContextInterface
 
 /**
  * 获取当前上下文
- *
- * @throws ZMKnownException
  */
 function ctx(): ContextInterface
 {

--- a/src/ZM/global_functions.php
+++ b/src/ZM/global_functions.php
@@ -13,6 +13,8 @@ use ZM\API\ZMRobot;
 use ZM\Config\ZMConfig;
 use ZM\ConnectionManager\ManagerGM;
 use ZM\Console\Console;
+use ZM\Container\Container;
+use ZM\Container\ContainerInterface;
 use ZM\Context\Context;
 use ZM\Context\ContextInterface;
 use ZM\Event\EventManager;
@@ -40,6 +42,7 @@ function get_class_path(string $class_name): ?string
 
 /**
  * 检查炸毛框架运行的环境
+ *
  * @internal
  */
 function _zm_env_check()
@@ -416,6 +419,7 @@ function server(): Server
 
 /**
  * 获取缓存当前框架pid的临时目录
+ *
  * @internal
  */
 function _zm_pid_dir(): string
@@ -433,6 +437,7 @@ function _zm_pid_dir(): string
  * 随机返回一个 ZMRobot 实例，效果等同于 {@link ZMRobot::getRandom()}。
  *
  * 在单机器人模式下，会直接返回该机器人实例。
+ *
  * @throws RobotNotFoundException
  */
 function bot(): ZMRobot
@@ -627,6 +632,7 @@ function zm_internal_errcode($code): string
 }
 
 /**
+<<<<<<< HEAD
  * 将可能为数组的参数转换为字符串
  *
  * 如传入字符串则为原样返回
@@ -636,6 +642,39 @@ function zm_internal_errcode($code): string
 function implode_when_necessary($string_or_array): string
 {
     return is_array($string_or_array) ? implode(', ', $string_or_array) : $string_or_array;
+}
+
+/**
+ * 获取容器（请求级）实例
+ */
+function container(): ContainerInterface
+{
+    return Container::getInstance();
+}
+
+/**
+ * 解析类实例（使用容器）
+ *
+ * @return mixed
+ */
+function resolve(string $abstract, array $parameters = [])
+{
+    return Container::getInstance()->make($abstract, $parameters);
+}
+
+/**
+ * 获取容器实例
+ *
+ * @param  null|string              $abstract 类或接口名，不传入则返回容器实例
+ * @return ContainerInterface|mixed
+ */
+function app(string $abstract = null, array $parameters = [])
+{
+    if (is_null($abstract)) {
+        return container();
+    }
+
+    return resolve($abstract, $parameters);
 }
 
 /**

--- a/src/ZM/global_functions.php
+++ b/src/ZM/global_functions.php
@@ -656,8 +656,8 @@ function container(): ContainerInterface
  * 解析类实例（使用容器）
  *
  * @template T
- * @param  string<T> $abstract
- * @return T
+ * @param  class-string<T> $abstract
+ * @return Closure|mixed|T
  */
 function resolve(string $abstract, array $parameters = [])
 {
@@ -668,8 +668,8 @@ function resolve(string $abstract, array $parameters = [])
  * 获取容器实例
  *
  * @template T
- * @param  null|string<T>       $abstract
- * @return ContainerInterface|T
+ * @param  null|class-string<T>               $abstract
+ * @return Closure|ContainerInterface|mixed|T
  */
 function app(string $abstract = null, array $parameters = [])
 {

--- a/tests/ZM/Container/ContainerCallTest.php
+++ b/tests/ZM/Container/ContainerCallTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\ZM\Container;
+
+use PHPUnit\Framework\TestCase;
+use ZM\Container\Container;
+
+/**
+ * @internal
+ */
+class ContainerCallTest extends TestCase
+{
+    public function testCallInvokableClass(): void
+    {
+        $container = new Container();
+        $this->assertEquals('foo', $container->call(Invokable::class, ['echo' => 'foo']));
+    }
+
+    public function testCallClassMethodWithDependencies(): void
+    {
+        $container = new Container();
+        $name = 'Steve' . time();
+        $container->bind(FooDependency::class, FooDependencyImpl::class);
+        $container->bind(BarDependency::class, function () use ($name) {
+            return new BarDependencyImpl($name);
+        });
+        $this->assertEquals("hello, {$name}", $container->call([Foo::class, 'sayHello']));
+    }
+
+    public function testCallClassStaticMethodWithDependencies(): void
+    {
+        $container = new Container();
+        $name = 'Alex' . time();
+        $container->bind(FooDependency::class, FooDependencyImpl::class);
+        $container->bind(BarDependency::class, function () use ($name) {
+            return new BarDependencyImpl($name);
+        });
+        $this->assertEquals("hello, {$name}", $container->call([Foo::class, 'staticSayHello']));
+    }
+
+    public function testCallClassMethodWithDependenciesInjectedByConstructor(): void
+    {
+        $container = new Container();
+        $name = 'Donny' . time();
+        $container->bind(FooDependency::class, FooDependencyImpl::class);
+        $container->bind(BarDependency::class, function () use ($name) {
+            return new BarDependencyImpl($name);
+        });
+        $this->assertEquals('goodbye', $container->call([Foo::class, 'sayGoodbye']));
+    }
+
+    public function testCallClassStaticMethodViaDoubleColons(): void
+    {
+        $container = new Container();
+        $name = 'Herobrine' . time();
+        $container->bind(FooDependency::class, FooDependencyImpl::class);
+        $container->bind(BarDependency::class, function () use ($name) {
+            return new BarDependencyImpl($name);
+        });
+        $this->assertEquals("hello, {$name}", $container->call(Foo::class . '::staticSayHello'));
+    }
+}
+
+class Invokable
+{
+    public function __invoke(string $echo)
+    {
+        return $echo;
+    }
+}
+
+interface FooDependency
+{
+    public function sayGoodbye(): string;
+}
+
+class FooDependencyImpl implements FooDependency
+{
+    public function sayGoodbye(): string
+    {
+        return 'goodbye';
+    }
+}
+
+interface BarDependency
+{
+    public function getName(): string;
+}
+
+class BarDependencyImpl implements BarDependency
+{
+    private $name;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+}
+
+class Foo
+{
+    private $fooDependency;
+
+    public function __construct(FooDependency $fooDependency)
+    {
+        $this->fooDependency = $fooDependency;
+    }
+
+    public function sayHello(BarDependency $barDependency): string
+    {
+        return 'hello, ' . $barDependency->getName();
+    }
+
+    public static function staticSayHello(BarDependency $barDependency): string
+    {
+        return 'hello, ' . $barDependency->getName();
+    }
+
+    public function sayGoodbye(): string
+    {
+        return $this->fooDependency->sayGoodbye();
+    }
+}

--- a/tests/ZM/Container/ContainerTest.php
+++ b/tests/ZM/Container/ContainerTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\ZM\Container;
+
+use PHPUnit\Framework\TestCase;
+use ZM\Container\Container;
+use ZM\Container\WorkerContainer;
+
+/**
+ * @internal
+ */
+class ContainerTest extends TestCase
+{
+    public function testInherit(): void
+    {
+        $worker_container = new WorkerContainer();
+        $worker_container->instance('foo', 'bar');
+
+        $container = new Container($worker_container);
+        $container->instance('baz', 'qux');
+
+        // 获取父容器的实例
+        $this->assertEquals('bar', $container->get('foo'));
+
+        // 获取自身容器的实例
+        $this->assertEquals('qux', $container->get('baz'));
+    }
+}

--- a/tests/ZM/Container/WorkerContainerTest.php
+++ b/tests/ZM/Container/WorkerContainerTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\ZM\Container;
+
+use PHPUnit\Framework\TestCase;
+use ZM\Container\EntryResolutionException;
+use ZM\Container\WorkerContainer;
+use ZM\Utils\MessageUtil;
+
+/**
+ * @internal
+ */
+class WorkerContainerTest extends TestCase
+{
+    private $container;
+
+    protected function setUp(): void
+    {
+        $this->container = new WorkerContainer();
+        $this->container->flush();
+    }
+
+    public function testInstance(): void
+    {
+        $this->container->instance('test', 'test');
+        $this->assertEquals('test', $this->container->make('test'));
+
+        $t2 = new WorkerContainer();
+        $this->assertEquals('test', $t2->make('test'));
+    }
+
+    public function testAlias(): void
+    {
+        $this->container->alias(MessageUtil::class, 'bar');
+        $this->container->alias('bar', 'baz');
+        $this->container->alias('baz', 'bas');
+        $this->assertInstanceOf(MessageUtil::class, $this->container->make('bas'));
+    }
+
+    public function testGetAlias(): void
+    {
+        $this->container->alias(MessageUtil::class, 'bar');
+        $this->assertEquals(MessageUtil::class, $this->container->getAlias('bar'));
+    }
+
+    public function testBindClosure(): void
+    {
+        $this->container->bind('test', function () {
+            return 'test';
+        });
+        $this->assertEquals('test', $this->container->make('test'));
+    }
+
+    public function testFlush(): void
+    {
+        $this->container->bind('test', function () {
+            return 'test';
+        });
+        $this->container->flush();
+        $this->expectException(EntryResolutionException::class);
+        $this->container->make('test');
+    }
+
+    public function testBindIf(): void
+    {
+        $this->container->bind('test', function () {
+            return 'test';
+        });
+        $this->container->bindIf('test', function () {
+            return 'test2';
+        });
+        $this->assertEquals('test', $this->container->make('test'));
+    }
+
+    public function testGet(): void
+    {
+        $this->testMake();
+    }
+
+    public function testBound(): void
+    {
+        $this->container->bind('test', function () {
+            return 'test';
+        });
+        $this->assertTrue($this->container->bound('test'));
+        $this->assertFalse($this->container->bound('test2'));
+    }
+
+    public function testFactory(): void
+    {
+        $this->container->bind('test', function () {
+            return 'test';
+        });
+        $factory = $this->container->factory('test');
+        $this->assertEquals($this->container->make('test'), $factory());
+    }
+
+    public function testMake(): void
+    {
+        $this->container->bind('test', function () {
+            return 'test';
+        });
+        $this->assertEquals('test', $this->container->make('test'));
+    }
+
+    public function testHas(): void
+    {
+        $this->testBound();
+    }
+
+    public function testBuild(): void
+    {
+        $this->assertEquals('test', $this->container->build(function () {
+            return 'test';
+        }));
+        $this->assertInstanceOf(MessageUtil::class, $this->container->build(MessageUtil::class));
+    }
+}


### PR DESCRIPTION
预计实现两个容器，一个为请求容器（Container，每个请求的都是独立的，适用于 Request / Context 等实例），一个为进程容器（WorkerContainer，作用于整个 Worker，在 Worker 初始化时初始化，用以保持请求容器和一些进程单例）。

容器基于 Illuminate Container 简化、改写而成，兼容 PSR-11 规范。

理论上请求容器可以无限套娃，但具体表现未测试。

目前已实现：
- [x] 请求容器
- [x] 进程容器
- [x] 简单与框架结合
- [x] 测试