### PR TITLE
添加容器有序无名参数动态调用支持

### DIFF
--- a/src/ZM/Container/BoundMethod.php
+++ b/src/ZM/Container/BoundMethod.php
@@ -51,7 +51,13 @@ class BoundMethod
     {
         $dependencies = [];
 
-        foreach (ReflectionUtil::getCallReflector($callback)->getParameters() as $parameter) {
+        foreach (ReflectionUtil::getCallReflector($callback)->getParameters() as $i => $parameter) {
+            if (isset($parameters[$i]) && $parameter->hasType() && ($type = $parameter->getType())) {
+                if ($type instanceof \ReflectionNamedType && gettype($parameters[$i]) === $type->getName()) {
+                    $dependencies[] = $parameters[$i];
+                    continue;
+                }
+            }
             static::addDependencyForCallParameter($container, $parameter, $parameters, $dependencies);
         }
 


### PR DESCRIPTION
现支持 `container()->call($callback, 'hello', new obj())` 调用，有效增加旧代码的兼容性。