### PR TITLE
轻量重构 Framework 类

### DIFF
--- a/config/logging.php
+++ b/config/logging.php
@@ -8,12 +8,16 @@ use ZM\Logger\ConsoleLogger;
 
 return [
     'level' => LogLevel::DEBUG,
-    'logger' => static function (): LoggerInterface {
-        // 在 Master 中，worker_id 将不存在
-        $worker_id = app()->has('worker_id') ? '#' . app('worker_id') : 'Master';
+    'logger' => static function (string $title = null): LoggerInterface {
+        if ($title) {
+            $title = strtoupper($title);
+        } else {
+            // 在 Master 中，worker_id 将不存在
+            $title = app()->has('worker_id') ? '#' . app('worker_id') : 'MST';
+        }
 
         $logger = new ConsoleLogger(zm_config('logging.level'));
-        $logger::$format = "[%date%] [%level%] [{$worker_id}] %body%";
+        $logger::$format = "[%date%] [%level%] [{$title}] %body%";
         $logger::$date_format = 'Y-m-d H:i:s';
         // 如果你喜欢旧版的日志格式，请取消下行注释
 //        $logger::$date_format = 'm-d H:i:s';

--- a/config/logging.php
+++ b/config/logging.php
@@ -9,10 +9,11 @@ use ZM\Logger\ConsoleLogger;
 return [
     'level' => LogLevel::DEBUG,
     'logger' => static function (): LoggerInterface {
-        $worker_id = app('worker_id');
+        // 在 Master 中，worker_id 将不存在
+        $worker_id = app()->has('worker_id') ? '#' . app('worker_id') : 'Master';
 
         $logger = new ConsoleLogger(zm_config('logging.level'));
-        $logger::$format = "[%date%] [%level%] [#{$worker_id}] %body%";
+        $logger::$format = "[%date%] [%level%] [{$worker_id}] %body%";
         $logger::$date_format = 'Y-m-d H:i:s';
         // 如果你喜欢旧版的日志格式，请取消下行注释
 //        $logger::$date_format = 'm-d H:i:s';

--- a/src/ZM/Framework.php
+++ b/src/ZM/Framework.php
@@ -313,7 +313,7 @@ class Framework
                 ];
                 $level_tip = $tips[$error_no] ?? ['PHP Unknown: ', 'error'];
                 $error = $level_tip[0] . $error_msg . ' in ' . $error_file . ' on ' . $error_line;
-                logger()->{$level_tip}[1]($error);
+                logger()->{$level_tip[1]}($error);
                 // 如果 return false 则错误会继续递交给 PHP 标准错误处理
                 return true;
             }, E_ALL | E_STRICT);

--- a/src/ZM/global_functions.php
+++ b/src/ZM/global_functions.php
@@ -788,10 +788,20 @@ function is_assoc_array(array $array): bool
 /**
  * 返回 Logger 实例
  */
-function logger(): LoggerInterface
+function logger(...$args): LoggerInterface
 {
     if (!app()->has(LoggerInterface::class)) {
-        return zm_config('logging.logger')();
+        return zm_config('logging.logger')(...$args);
     }
     return resolve(LoggerInterface::class);
+}
+
+/**
+ * 捕获输出
+ */
+function capture_output(callable $callback, array $args = []): string
+{
+    ob_start();
+    $callback(...$args);
+    return ob_get_clean();
 }

--- a/src/ZM/global_functions.php
+++ b/src/ZM/global_functions.php
@@ -790,5 +790,8 @@ function is_assoc_array(array $array): bool
  */
 function logger(): LoggerInterface
 {
+    if (!app()->has(LoggerInterface::class)) {
+        return zm_config('logging.logger')();
+    }
     return resolve(LoggerInterface::class);
 }


### PR DESCRIPTION
- 使用 `zhamao/logger` 替换了原有的 `zhamao/console`
- 为 `logger` 函数（和 `logger`）增加了自定义 TITLE 的功能
- 拆分了 `printPropertes` 以增加维护性
- 重新调整了全局错误处理器，更加简洁
- 汉化了部分错误、提示信息
- 重新排序了方法
- 命令行传入的参数错误时，框架将会直接退出，不再使用默认值运行
- 新增了 `capture_output` 全局函数，以方便捕获输出

日志输出至文件功能尚未实现，预计于日后的 PR 中使用 `logger callback` 实现，仅支持 `zhamao/logger`。