### PR TITLE
解决explode_msg中，传入参数为0时，参数0消失的BUG

### DIFF
--- a/src/ZM/global_functions.php
+++ b/src/ZM/global_functions.php
@@ -75,7 +75,7 @@ function explode_msg(string $msg, array $includes = [' ', "\t"]): array
     $msg_seg = explode("\n", $msg);
     $ls = [];
     foreach ($msg_seg as $v) {
-        if (empty(trim($v))) {
+        if (empty(trim($v)) && trim($v) != 0) {
             continue;
         }
         $ls[] = trim($v);

--- a/src/ZM/global_functions.php
+++ b/src/ZM/global_functions.php
@@ -75,7 +75,7 @@ function explode_msg(string $msg, array $includes = [' ', "\t"]): array
     $msg_seg = explode("\n", $msg);
     $ls = [];
     foreach ($msg_seg as $v) {
-        if (empty(trim($v)) && trim($v) != 0) {
+        if (trim($v) === '') {
             continue;
         }
         $ls[] = trim($v);


### PR DESCRIPTION
### 原因
在`explode_msg()`中，使用的`empty()`函数会将整数`0`以及字符串`0`判定为`true`，从而导致参数消失，需要对此进行特判。

### 过程
在使用`ctx() -> getNextMsg()`时，参数丢失，发现`ctx()->getCache()`中的消息也存在参数丢失，定位到`QQBot`的`dispatchEvents`分发消息时，从`MessageUtil::matchCommand`开始出现丢失的现象，进而发现在`MessageUtil`中`splitCommand`的`explode_msg`出现问题。

  另外，这个问题和ISSUE#140有相似之处，是否存在其他类似问题？
