### PR TITLE
改进测试运行

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
         "brainmaestro/composer-git-hooks": "^3.0",
         "friendsofphp/php-cs-fixer": "^3.2 != 3.7.0",
         "jetbrains/phpstorm-attributes": "^1.0",
+        "phpspec/prophecy": "1.x-dev",
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan": "^1.1",
         "phpstan/phpstan-deprecation-rules": "^1.0",
@@ -39,6 +40,9 @@
         "phpunit/phpunit": "^8.5 || ^9.0",
         "roave/security-advisories": "dev-latest",
         "swoole/ide-helper": "^4.5"
+    },
+    "replace": {
+        "symfony/polyfill-php80": "*"
     },
     "suggest": {
         "ext-ctype": "Use C/C++ extension instead of polyfill will be more efficient",
@@ -48,6 +52,7 @@
         "league/climate": "Display columns and status in terminal"
     },
     "minimum-stability": "dev",
+    "prefer-stable": true,
     "autoload": {
         "psr-4": {
             "ZM\\": "src/ZM"
@@ -70,11 +75,11 @@
         "bin/zhamao"
     ],
     "config": {
-        "optimize-autoloader": true,
-        "sort-packages": true,
         "allow-plugins": {
             "phpstan/extension-installer": true
-        }
+        },
+        "optimize-autoloader": true,
+        "sort-packages": true
     },
     "extra": {
         "hooks": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,6 +3,7 @@ parameters:
   level: 4
   paths:
     - ./src/
+    - ./tests/
   ignoreErrors:
     - '#Constant .* not found#'
     - '#PHPDoc tag @throws with type Psr\\Container\\ContainerExceptionInterface is not subtype of Throwable#'

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use Prophecy\Prophet;
+
+/**
+ * @internal
+ */
+class TestCase extends \PHPUnit\Framework\TestCase
+{
+    protected Prophet $prophet;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->prophet = new Prophet();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        $this->prophet->checkPredictions();
+    }
+}

--- a/tests/Trait/HasLogger.php
+++ b/tests/Trait/HasLogger.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Trait;
+
+use Prophecy\Prophet;
+use Psr\Log\AbstractLogger;
+
+/**
+ * 模拟 Logger 行为
+ * @property Prophet $prophet
+ */
+trait HasLogger
+{
+    private array $logs = [];
+
+    private function mockLog($level, $message, array $context = []): void
+    {
+        $this->logs[] = compact('level', 'message', 'context');
+    }
+
+    private function logged($level, $message, array $context = []): bool
+    {
+        return in_array(compact('level', 'message', 'context'), $this->logs, true);
+    }
+
+    private function assertLogged($level, $message = null, array $context = []): void
+    {
+        $this->assertTrue(
+            $this->logged($level, $message, $context),
+            "Failed asserting that the log contains [{$level}] {$message}"
+        );
+    }
+
+    private function startMockLogger(): void
+    {
+        $logger = $this->prophet->prophesize(AbstractLogger::class);
+        $logger->log()->will(function ($args) {
+            $this->mockLog(...$args);
+        });
+        ob_logger_register($logger->reveal());
+    }
+}

--- a/tests/ZM/Config/ZMConfigTest.php
+++ b/tests/ZM/Config/ZMConfigTest.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 
 namespace Tests\ZM\Config;
 
-use PHPUnit\Framework\TestCase;
+use Tests\TestCase;
 use ZM\Config\ZMConfig;
+use ZM\Exception\ConfigException;
 use ZM\Utils\ReflectionUtil;
 
 /**
@@ -64,9 +65,13 @@ class ZMConfigTest extends TestCase
             '<?php return ["patch" => "yes", "another array" => ["far", "baz"]];'
         );
 
-        $config = new ZMConfig([
-            __DIR__ . '/config_mock',
-        ], 'development');
+        try {
+            $config = new ZMConfig([
+                __DIR__ . '/config_mock',
+            ], 'development');
+        } catch (ConfigException $e) {
+            self::fail($e->getMessage());
+        }
         self::$config = $config;
     }
 
@@ -83,8 +88,8 @@ class ZMConfigTest extends TestCase
     public function testGetValueWhenKeyContainsDot(): void
     {
         $this->markTestSkipped('should it be supported?');
-        $this->assertEquals('c', self::$config->get('test.a.b'));
-        $this->assertEquals('d', self::$config->get('test.a.b.c'));
+//        $this->assertEquals('c', self::$config->get('test.a.b'));
+//        $this->assertEquals('d', self::$config->get('test.a.b.c'));
     }
 
     public function testGetBooleanValue(): void

--- a/tests/ZM/Middleware/PipelineTest.php
+++ b/tests/ZM/Middleware/PipelineTest.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\ZM\Middleware;
 
-use PHPUnit\Framework\TestCase;
-use ZM\Logger\ConsoleLogger;
+use Tests\TestCase;
 use ZM\Middleware\Pipeline;
 use ZM\Middleware\TimerMiddleware;
 
@@ -14,16 +13,6 @@ use ZM\Middleware\TimerMiddleware;
  */
 class PipelineTest extends TestCase
 {
-    public function setUp(): void
-    {
-        ob_logger_register(new ConsoleLogger('debug'));
-    }
-
-    public function tearDown(): void
-    {
-        ob_logger_register(new ConsoleLogger('error'));
-    }
-
     public function testPipeline()
     {
         $pipe = new Pipeline();

--- a/tests/ZM/Utils/ReflectionUtilTest.php
+++ b/tests/ZM/Utils/ReflectionUtilTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\ZM\Utils;
 
-use PHPUnit\Framework\TestCase;
+use Tests\TestCase;
 use ZM\Utils\ReflectionUtil;
 
 /**

--- a/tests/ZM/Utils/ZMUtilTest.php
+++ b/tests/ZM/Utils/ZMUtilTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\ZM\Utils;
 
-use PHPUnit\Framework\TestCase;
+use Tests\TestCase;
 use ZM\Utils\ZMUtil;
 
 /**


### PR DESCRIPTION
- 引入了 Prophecy 对象模仿框架
- 新增了 HasLogger Trait，用以模仿 Logger 行为，在不实际输出到终端的情况下测试日志
- 优化了部分测试的结构
- 将 `symfony/polyfill-php80` 加入黑名单，以避免被其他依赖引入 `php-cs-fixer`
- 将 `tests` 目录加入到 `phpstan` 的覆盖范围
- 将 `composer.json` 的 `prefer-stable` 设为 `true`
