### PR TITLE
修复 getClassesPsr4 中默认过滤方法的路径 Bug 

### DIFF
--- a/src/ZM/Store/FileSystem.php
+++ b/src/ZM/Store/FileSystem.php
@@ -142,7 +142,7 @@ class FileSystem
                     /*if (substr(file_get_contents($dir . '/' . $v), 6, 6) == '#plain') {
                         continue;
                     }*/
-                    if (file_exists($dir . '/' . $pathinfo['basename'] . '.ignore')) {
+                    if (file_exists($dir . '/' . $v . '.ignore')) {
                         continue;
                     }
                     if (mb_substr($pathinfo['basename'], 0, 7) == 'global_' || mb_substr($pathinfo['basename'], 0, 7) == 'script_') {


### PR DESCRIPTION
和 2.x 同样的 Bug