### PR TITLE
修复 BotCommand 使用 regex 时参数错乱的 Bug

### DIFF
--- a/src/ZM/Plugin/OneBot12Adapter.php
+++ b/src/ZM/Plugin/OneBot12Adapter.php
@@ -464,6 +464,7 @@ class OneBot12Adapter extends ZMPlugin
             }
             // 测试 regex
             if ($v->regex !== '' && preg_match('/' . $v->regex . '/u', $full_str, $match) !== 0) {
+                array_shift($match);
                 return [$v, $match, $full_str];
             }
             // 测试 start_with


### PR DESCRIPTION
参数的 match 第一个不需要，要去掉才能正常使用 CommandArgument。