### PR TITLE
为键名使用强制类型转换string

### DIFF
--- a/src/ZM/Store/LightCache.php
+++ b/src/ZM/Store/LightCache.php
@@ -75,7 +75,7 @@ class LightCache
                 } else {
                     return false;
                 }
-                $result = self::$kv_table->set($k, [
+                $result = self::$kv_table->set((string)$k, [
                     'value' => $value,
                     'expire' => $v['expire'],
                     'data_type' => $data_type,


### PR DESCRIPTION
使用数字作为键名时set()成功保存 但是停止框架后再启动框架数据落地恢复时报错类型不符合
Fatal error: Uncaught TypeError: Swoole\Table::set(): Argument #1 ($key) must be of type string, int given in zhamao/vendor/zhamao/framework/src/ZM/Store/LightCache.php:81