### PR TITLE
插件生成器和插件列表的相关破坏性更新

### DIFF
--- a/src/Templates/PluginMain.php.template
+++ b/src/Templates/PluginMain.php.template
@@ -6,7 +6,7 @@ namespace {namespace};
 
 class {class}
 {
-    #[\BotCommand(match: '测试{name}')]
+    #[\BotCommand(match: '测试{basename}')]
     public function firstBotCommand(\BotContext $ctx): void
     {
         $ctx->reply('这是{name}插件的第一个命令！');

--- a/src/Templates/PluginMain.php.template
+++ b/src/Templates/PluginMain.php.template
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace {namespace};
 
+use ZM\Annotation\OneBot\BotCommand;
+use ZM\Context\BotContext;
+
 class {class}
 {
-    #[\BotCommand(match: '测试{basename}')]
-    public function firstBotCommand(\BotContext $ctx): void
+    #[BotCommand(match: '测试{basename}')]
+    public function firstBotCommand(BotContext $ctx): void
     {
         $ctx->reply('这是{name}插件的第一个命令！');
     }

--- a/src/Templates/main.php.template
+++ b/src/Templates/main.php.template
@@ -5,9 +5,9 @@ declare(strict_types=1);
 $plugin = new ZMPlugin(__DIR__);
 
 /*
- * 发送 "测试{name}"，回复 "这是{name}插件的第一个命令！"
+ * 发送 "测试{basename}"，回复 "这是{basename}插件的第一个命令！"
  */
-$cmd1 = BotCommand::make('{name}', match: '测试{name}')->on(fn () => '这是{name}插件的第一个命令！');
+$cmd1 = BotCommand::make('{name}', match: '测试{basename}')->on(fn () => '这是{name}插件的第一个命令！');
 
 $plugin->addBotCommand($cmd1);
 

--- a/src/ZM/Bootstrap/LoadPlugins.php
+++ b/src/ZM/Bootstrap/LoadPlugins.php
@@ -14,5 +14,6 @@ class LoadPlugins
         $plugin_dir = config('global.plugin.load_dir', SOURCE_ROOT_DIR . '/plugins');
         // 模拟加载一遍插件
         PluginManager::addPluginsFromDir($plugin_dir);
+        PluginManager::addPluginsFromComposer();
     }
 }

--- a/src/ZM/Command/Command.php
+++ b/src/ZM/Command/Command.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace ZM\Command;
 
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-abstract class Command extends \Symfony\Component\Console\Command\Command
+abstract class Command extends \Symfony\Component\Console\Command\Command implements LoggerInterface
 {
     use CommandInteractTrait;
 

--- a/src/ZM/Command/Plugin/PluginCommand.php
+++ b/src/ZM/Command/Plugin/PluginCommand.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace ZM\Command\Plugin;
 
 use Symfony\Component\Console\Helper\QuestionHelper;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ChoiceQuestion;
 use Symfony\Component\Console\Question\Question;
 use ZM\Bootstrap;
@@ -21,6 +19,9 @@ abstract class PluginCommand extends Command
         Bootstrap\LoadConfiguration::class,
         Bootstrap\LoadPlugins::class,
     ];
+
+    /** @var null|string 动态插件和 Phar 插件的加载目录 */
+    protected ?string $plugin_dir = null;
 
     /**
      * 插件名称合规验证器
@@ -48,6 +49,9 @@ abstract class PluginCommand extends Command
         }
         if (PluginManager::isPluginExists($answer)) {
             throw new \RuntimeException('名称为 ' . $answer . ' 的插件已存在，请换个名字');
+        }
+        if (is_dir(zm_dir($this->plugin_dir . '/' . $exp[1]))) {
+            throw new \RuntimeException('本插件名称的插件开发目录已经有相同名称，请先将同名插件的目录名修改，或修改本插件名称');
         }
         return $answer;
     }
@@ -126,10 +130,5 @@ abstract class PluginCommand extends Command
             ZM_PLUGIN_TYPE_COMPOSER => 'Composer 外部加载',
             default => '未知模式'
         };
-    }
-
-    protected function execute(InputInterface $input, OutputInterface $output): int
-    {
-        return parent::execute($input, $output);
     }
 }

--- a/src/ZM/Command/Plugin/PluginCommand.php
+++ b/src/ZM/Command/Plugin/PluginCommand.php
@@ -125,9 +125,9 @@ abstract class PluginCommand extends Command
     {
         return match ($type) {
             ZM_PLUGIN_TYPE_NATIVE => '内部',
-            ZM_PLUGIN_TYPE_PHAR => 'Phar',
-            ZM_PLUGIN_TYPE_SOURCE => '源码',
-            ZM_PLUGIN_TYPE_COMPOSER => 'Composer 外部加载',
+            ZM_PLUGIN_TYPE_PHAR => '<comment>Phar</comment>',
+            ZM_PLUGIN_TYPE_SOURCE => '<fg=gray>源码</>',
+            ZM_PLUGIN_TYPE_COMPOSER => '<info>Composer</info>',
             default => '未知模式'
         };
     }

--- a/src/ZM/Command/Plugin/PluginCommand.php
+++ b/src/ZM/Command/Plugin/PluginCommand.php
@@ -4,10 +4,14 @@ declare(strict_types=1);
 
 namespace ZM\Command\Plugin;
 
+use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ChoiceQuestion;
+use Symfony\Component\Console\Question\Question;
 use ZM\Bootstrap;
 use ZM\Command\Command;
+use ZM\Plugin\PluginManager;
 
 abstract class PluginCommand extends Command
 {
@@ -17,6 +21,111 @@ abstract class PluginCommand extends Command
         Bootstrap\LoadConfiguration::class,
         Bootstrap\LoadPlugins::class,
     ];
+
+    /**
+     * 插件名称合规验证器
+     */
+    public function validatePluginName(string $answer): string
+    {
+        if (empty($answer)) {
+            throw new \RuntimeException('插件名称不能为空');
+        }
+        if (is_numeric(mb_substr($answer, 0, 1))) {
+            throw new \RuntimeException('插件名称不能以数字开头，且只能包含字母、数字、下划线、短横线');
+        }
+        if (!preg_match('/^[\/a-zA-Z0-9_-]+$/', $answer)) {
+            throw new \RuntimeException('插件名称只能包含字母、数字、下划线、短横线');
+        }
+        $exp = explode('/', $answer);
+        if (count($exp) !== 2) {
+            throw new \RuntimeException('插件名称必须为"组织或所有者/插件名称"的格式，且只允许有一个斜杠分割两者');
+        }
+        if ($exp[0] === 'zhamao') {
+            throw new \RuntimeException('插件所有者或组织名不可以为"zhamao"，请换个名字');
+        }
+        if ($exp[0] === '' || $exp[1] === '') {
+            throw new \RuntimeException('插件所有者或组织名、插件名称均不可为空');
+        }
+        if (PluginManager::isPluginExists($answer)) {
+            throw new \RuntimeException('名称为 ' . $answer . ' 的插件已存在，请换个名字');
+        }
+        return $answer;
+    }
+
+    /**
+     * 命名空间合规验证器
+     */
+    public function validateNamespace(string $answer): string
+    {
+        if (empty($answer)) {
+            throw new \RuntimeException('插件命名空间不能为空');
+        }
+        if (is_numeric(mb_substr($answer, 0, 1))) {
+            throw new \RuntimeException('插件命名空间不能以数字开头，且只能包含字母、数字、反斜线');
+        }
+        // 只能包含字母、数字和反斜线
+        if (!preg_match('/^[a-zA-Z0-9\\\\]+$/', $answer)) {
+            throw new \RuntimeException('插件命名空间只能包含字母、数字、反斜线');
+        }
+        return $answer;
+    }
+
+    /**
+     * 添加 Question 来询问缺失的参数
+     *
+     * @param string   $name      参数名称
+     * @param string   $question  问题
+     * @param callable $validator 验证器
+     */
+    protected function questionWithArgument(string $name, string $question, callable $validator): void
+    {
+        /** @var QuestionHelper $helper */
+        $helper = $this->getHelper('question');
+        $question = new Question('<question>' . $question . '</question>');
+        $question->setValidator($validator);
+        $this->input->setArgument($name, $helper->ask($this->input, $this->output, $question));
+    }
+
+    /**
+     * 添加 Question 来询问缺失的参数
+     *
+     * @param string   $name      参数名称
+     * @param string   $question  问题
+     * @param callable $validator 验证器
+     */
+    protected function questionWithOption(string $name, string $question, callable $validator): void
+    {
+        /** @var QuestionHelper $helper */
+        $helper = $this->getHelper('question');
+        $question = new Question('<question>' . $question . '</question>');
+        $question->setValidator($validator);
+        $this->input->setOption($name, $helper->ask($this->input, $this->output, $question));
+    }
+
+    /**
+     * 添加选择题来询问缺失的参数
+     *
+     * @param string $name      可选参数名称
+     * @param string $question  问题
+     * @param array  $selection 选项（K-V 类型）
+     */
+    protected function choiceWithOption(string $name, string $question, array $selection): void
+    {
+        /** @var QuestionHelper $helper */
+        $helper = $this->getHelper('question');
+        $question = new ChoiceQuestion('<question>' . $question . '</question>', $selection);
+        $this->input->setOption($name, $helper->ask($this->input, $this->output, $question));
+    }
+
+    protected function getTypeDisplayName(int $type): string
+    {
+        return match ($type) {
+            ZM_PLUGIN_TYPE_NATIVE => '内部',
+            ZM_PLUGIN_TYPE_PHAR => 'Phar',
+            ZM_PLUGIN_TYPE_SOURCE => '源码',
+            ZM_PLUGIN_TYPE_COMPOSER => 'Composer 外部加载'
+        };
+    }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {

--- a/src/ZM/Command/Plugin/PluginCommand.php
+++ b/src/ZM/Command/Plugin/PluginCommand.php
@@ -123,7 +123,8 @@ abstract class PluginCommand extends Command
             ZM_PLUGIN_TYPE_NATIVE => '内部',
             ZM_PLUGIN_TYPE_PHAR => 'Phar',
             ZM_PLUGIN_TYPE_SOURCE => '源码',
-            ZM_PLUGIN_TYPE_COMPOSER => 'Composer 外部加载'
+            ZM_PLUGIN_TYPE_COMPOSER => 'Composer 外部加载',
+            default => '未知模式'
         };
     }
 

--- a/src/ZM/Command/Plugin/PluginCommand.php
+++ b/src/ZM/Command/Plugin/PluginCommand.php
@@ -97,11 +97,11 @@ abstract class PluginCommand extends Command
      * @param string   $question  问题
      * @param callable $validator 验证器
      */
-    protected function questionWithOption(string $name, string $question, callable $validator): void
+    protected function questionWithOption(string $name, string $question, callable $validator, string $default = null): void
     {
         /** @var QuestionHelper $helper */
         $helper = $this->getHelper('question');
-        $question = new Question('<question>' . $question . '</question>');
+        $question = new Question('<question>' . $question . '</question>', $default);
         $question->setValidator($validator);
         $this->input->setOption($name, $helper->ask($this->input, $this->output, $question));
     }

--- a/src/ZM/Command/Plugin/PluginInstallCommand.php
+++ b/src/ZM/Command/Plugin/PluginInstallCommand.php
@@ -7,10 +7,9 @@ namespace ZM\Command\Plugin;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
-use ZM\Exception\FileSystemException;
-use ZM\Plugin\PluginManager;
+use ZM\Plugin\Strategy\ComposerStrategy;
+use ZM\Plugin\Strategy\GitStrategy;
 use ZM\Store\FileSystem;
-use ZM\Utils\ZMRequest;
 
 #[AsCommand(name: 'plugin:install', description: '从 GitHub 或其他 Git 源码托管站安装插件')]
 class PluginInstallCommand extends PluginCommand
@@ -18,6 +17,7 @@ class PluginInstallCommand extends PluginCommand
     protected function configure()
     {
         $this->addArgument('address', InputArgument::REQUIRED, '插件地址');
+        $this->addOption('github-token', null, InputOption::VALUE_REQUIRED, '提供的 GitHub Token');
 
         // 下面是辅助用的，和 server:start 一样
         $this->addOption('config-dir', null, InputOption::VALUE_REQUIRED, '指定其他配置文件目录');
@@ -29,87 +29,36 @@ class PluginInstallCommand extends PluginCommand
     protected function handle(): int
     {
         $addr = $this->input->getArgument('address');
-        $name = ob_uuidgen();
         $this->plugin_dir = FileSystem::isRelativePath(config('global.plugin.load_dir', 'plugins')) ? (WORKING_DIR . '/' . config('global.plugin.load_dir', 'plugins')) : config('global.plugin.load_dir', 'plugins');
-        // 先通过 GitHub API 获取看看存不存在 zmplugin.json
-        // 解析 git https 路径中的仓库所有者和仓库名
-        $git_url = parse_url($addr);
-        if ($git_url['host'] === 'github.com') {
-            $path = explode('/', $git_url['path']);
-            $owner = $path[1];
-            $repo = $path[2];
-            if (str_ends_with($repo, '.git')) {
-                $repo = substr($repo, 0, -4);
-            }
-            $api = ZMRequest::get('https://api.github.com/repos/' . $owner . '/' . $repo . '/contents/zmplugin.json', ['User-Agent' => 'ZMFramework']);
-            if ($api === false) {
-                $this->error('GitHub API 请求失败');
-                return static::FAILURE;
-            }
-            $api = json_decode($api, true);
-            if (isset($api['message'])) {
-                $this->error('该项目中不存在 zmplugin.json 元信息！');
-                return static::FAILURE;
-            }
-            $contents = implode('', array_map(fn ($x) => base64_decode($x), explode("\n", $api['content'])));
-            $json = json_decode($contents, true);
-            if (!isset($json['name'])) {
-                $this->error('插件元信息内没有名字！');
-                return static::FAILURE;
-            }
-            $plugin_name = $json['name'];
-            if (PluginManager::isPluginExists($plugin_name)) {
-                $this->error('插件 ' . $plugin_name . ' 已存在，无法再次安装！');
-                return static::FAILURE;
-            }
+
+        // 先检查传入的参数是什么类型。如果是 a/b 类型则为 composer 包
+        if (count(explode('/', $addr)) === 2) {
+            $st = new ComposerStrategy($addr, $this->plugin_dir, logger: $this);
+        } elseif ((parse_url($addr)['scheme'] ?? null) !== null) {
+            $st = new GitStrategy($addr, $this->plugin_dir, logger: $this);
+        } else {
+            $this->error('无法检测输入要安装插件的链接或名字，请检查后再试！');
+            return static::FAILURE;
         }
-        $this->info('正在从 ' . $addr . ' 克隆插件仓库');
+
+        if ($token = $this->input->getOption('github-token')) {
+            $option = ['github-token' => $token];
+        } else {
+            $option = [];
+        }
+        // 然后调用安装并看是否成功
         try {
-            FileSystem::createDir($this->plugin_dir);
-        } catch (FileSystemException $exception) {
-            $this->error("无法创建插件目录 {$this->plugin_dir}：{$exception->getMessage()}");
-            return static::FAILURE;
-        }
-        passthru('cd ' . escapeshellarg($this->plugin_dir) . ' && git clone --depth=1 ' . escapeshellarg($addr) . ' ' . $name, $code);
-        if ($code !== 0) {
-            $this->error('无法从指定 Git 地址拉取项目，请检查地址名是否正确');
-            return static::FAILURE;
-        }
-        if (!file_exists($this->plugin_dir . '/' . $name . '/zmplugin.json')) {
-            $this->error('项目不存在 zmplugin.json 插件元信息，无法安装，请手动删除目录 ' . $name);
-            // TODO: 使用 rmdir 和 unlink 删除 git 目录
-            return static::FAILURE;
-        }
-        $this->output->writeln('正在检查元信息完整性');
-        $getname = json_decode(file_get_contents($this->plugin_dir . '/' . $name . '/zmplugin.json'), true)['name'] ?? null;
-        if ($getname === null) {
-            $this->error('无法获取元信息 zmplugin.json');
-            return static::FAILURE;
-        }
-        $code = rename($this->plugin_dir . '/' . $name, $this->plugin_dir . '/' . $getname);
-        if ($code === false) {
-            $this->error('无法重命名文件夹 ' . $name);
-            return static::FAILURE;
-        }
-        if (file_exists($this->plugin_dir . '/' . $getname . '/composer.json')) {
-            $this->info('插件存在 composer.json，正在安装 composer 相关依赖（需要系统环境变量中包含 composer 路径）');
-            $cwd = getcwd();
-            chdir($this->plugin_dir . '/' . $getname);
-            // 使用内建 Composer
-            if (file_exists(WORKING_DIR . '/runtime/composer.phar')) {
-                $this->info('使用内建 Composer');
-                passthru(PHP_BINARY . ' ' . escapeshellarg(WORKING_DIR . '/runtime/composer.phar') . ' install --no-dev', $code);
-            } else {
-                $this->info('使用系统 Composer');
-                passthru('composer install --no-dev', $code);
-            }
-            chdir($cwd);
-            if ($code != 0) {
-                $this->error('无法安装 Composer 依赖，请检查 Composer 是否可以正常运行');
+            if (!$st->install($option)) {
+                $this->error('插件安装失败，' . $st->getError());
                 return static::FAILURE;
             }
+        } catch (\Throwable $e) {
+            $this->error('niu: ' . $e->getMessage());
+            $this->error($e->getTraceAsString());
+            return static::FAILURE;
         }
-        $this->info('插件 ' . $getname . ' 安装成功！');
+
+        $this->info('插件 ' . $st->getInstalledName() . ' 安装成功！');
         return static::SUCCESS;
     }
 }

--- a/src/ZM/Command/Plugin/PluginListCommand.php
+++ b/src/ZM/Command/Plugin/PluginListCommand.php
@@ -32,6 +32,7 @@ class PluginListCommand extends PluginCommand
         }
         $table = new Table($this->output);
         $table->setColumnMaxWidth(2, 27);
+        $table->setHeaderTitle('插件列表');
         $table->setHeaders(['名称', '版本', '简介', '类型']);
         foreach ($all as $k => $v) {
             $table->addRow([$k, $v->getVersion(), $v->getDescription(), $this->getTypeDisplayName($v->getPluginType())]);

--- a/src/ZM/Command/Plugin/PluginListCommand.php
+++ b/src/ZM/Command/Plugin/PluginListCommand.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZM\Command\Plugin;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Helper\Table;
+use ZM\Plugin\PluginManager;
+
+#[AsCommand(name: 'plugin:list', description: '显示插件列表')]
+class PluginListCommand extends PluginCommand
+{
+    protected function handle(): int
+    {
+        $all = PluginManager::getPlugins();
+        $table = new Table($this->output);
+        $table->setHeaders(['名称', '版本', '类型']);
+        foreach ($all as $k => $v) {
+            $table->addRow([$k, $v->getVersion(), $this->getTypeDisplayName($v->getPluginType())]);
+        }
+        $table->setStyle('box');
+        $table->render();
+        return static::SUCCESS;
+    }
+}

--- a/src/ZM/Command/Plugin/PluginListCommand.php
+++ b/src/ZM/Command/Plugin/PluginListCommand.php
@@ -11,13 +11,30 @@ use ZM\Plugin\PluginManager;
 #[AsCommand(name: 'plugin:list', description: '显示插件列表')]
 class PluginListCommand extends PluginCommand
 {
+    protected function configure()
+    {
+        $this->addOption('name-list', 'N', null, '只输出插件列表的名字');
+    }
+
     protected function handle(): int
     {
         $all = PluginManager::getPlugins();
+        if ($all === []) {
+            $this->info('当前未安装任何插件');
+            return static::SUCCESS;
+        }
+        if ($this->input->getOption('name-list')) {
+            $this->info('插件列表: ');
+            foreach ($all as $k => $v) {
+                $this->write($k);
+            }
+            return static::SUCCESS;
+        }
         $table = new Table($this->output);
-        $table->setHeaders(['名称', '版本', '类型']);
+        $table->setColumnMaxWidth(2, 27);
+        $table->setHeaders(['名称', '版本', '简介', '类型']);
         foreach ($all as $k => $v) {
-            $table->addRow([$k, $v->getVersion(), $this->getTypeDisplayName($v->getPluginType())]);
+            $table->addRow([$k, $v->getVersion(), $v->getDescription(), $this->getTypeDisplayName($v->getPluginType())]);
         }
         $table->setStyle('box');
         $table->render();

--- a/src/ZM/Command/Plugin/PluginMakeCommand.php
+++ b/src/ZM/Command/Plugin/PluginMakeCommand.php
@@ -7,6 +7,7 @@ namespace ZM\Command\Plugin;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
+use ZM\Exception\FileSystemException;
 use ZM\Store\FileSystem;
 use ZM\Utils\CodeGenerator\PluginGenerator;
 
@@ -30,6 +31,7 @@ class PluginMakeCommand extends PluginCommand
 
     /**
      * {@inheritDoc}
+     * @throws FileSystemException
      */
     protected function handle(): int
     {
@@ -57,15 +59,16 @@ class PluginMakeCommand extends PluginCommand
         if ($this->input->getOption('type') === 'psr4') {
             // 询问命名空间
             if ($this->input->getOption('namespace') === null) {
-                $this->questionWithOption('namespace', '请输入插件命名空间：', [$this, 'validateNamespace']);
+                $default_namespace = explode('/', $this->input->getArgument('name'))[0];
+                $this->questionWithOption('namespace', '请输入插件命名空间，输入则使用自定义，回车默认使用 [' . $default_namespace . ']：', [$this, 'validateNamespace'], $default_namespace);
             }
         }
 
         $generator = new PluginGenerator($this->input->getArgument('name'), $this->plugin_dir);
-        $generator->generate($this->input->getOptions());
+        $dir = $generator->generate($this->input->getOptions());
 
         $this->info('已生成插件：' . $this->input->getArgument('name'));
-        $this->info('目录位置：' . zm_dir($this->plugin_dir . '/' . $this->input->getArgument('name')));
+        $this->info('目录位置：' . $dir);
         return self::SUCCESS;
     }
 }

--- a/src/ZM/Command/Plugin/PluginMakeCommand.php
+++ b/src/ZM/Command/Plugin/PluginMakeCommand.php
@@ -39,7 +39,7 @@ class PluginMakeCommand extends PluginCommand
         } elseif (FileSystem::isRelativePath($load_dir)) {
             $load_dir = SOURCE_ROOT_DIR . '/' . $load_dir;
         }
-        $plugin_dir = zm_dir($load_dir);
+        $this->plugin_dir = zm_dir($load_dir);
 
         // 询问插件名称
         if ($this->input->getArgument('name') === null) {
@@ -61,11 +61,11 @@ class PluginMakeCommand extends PluginCommand
             }
         }
 
-        $generator = new PluginGenerator($this->input->getArgument('name'), $plugin_dir);
+        $generator = new PluginGenerator($this->input->getArgument('name'), $this->plugin_dir);
         $generator->generate($this->input->getOptions());
 
         $this->info('已生成插件：' . $this->input->getArgument('name'));
-        $this->info('目录位置：' . zm_dir($plugin_dir . '/' . $this->input->getArgument('name')));
+        $this->info('目录位置：' . zm_dir($this->plugin_dir . '/' . $this->input->getArgument('name')));
         return self::SUCCESS;
     }
 }

--- a/src/ZM/Command/Server/ServerStartCommand.php
+++ b/src/ZM/Command/Server/ServerStartCommand.php
@@ -37,6 +37,7 @@ class ServerStartCommand extends ServerCommand
             new InputOption('no-state-check', null, null, '关闭启动前框架运行状态检查'),
             new InputOption('private-mode', null, null, '启动时隐藏MOTD和敏感信息'),
             new InputOption('print-process-pid', null, null, '打印所有进程的PID'),
+            new InputOption('disable-plugins', null, InputOption::VALUE_REQUIRED, '要禁用的插件，如需多个，采用逗号分割名称'),
         ]);
         $this->setHelp('直接运行可以启动');
     }

--- a/src/ZM/ConsoleApplication.php
+++ b/src/ZM/ConsoleApplication.php
@@ -88,6 +88,7 @@ final class ConsoleApplication extends Application
      */
     public function run(InputInterface $input = null, OutputInterface $output = null): int
     {
+        // 注册 bootstrap
         $options = $input?->getOptions() ?? ServerStartCommand::exportOptionArray();
         foreach ($this->bootstrappers as $bootstrapper) {
             resolve($bootstrapper)->bootstrap($options);
@@ -95,7 +96,7 @@ final class ConsoleApplication extends Application
 
         try {
             return parent::run($input, $output);
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             echo zm_internal_errcode('E00005') . "{$e->getMessage()} at {$e->getFile()}({$e->getLine()})" . PHP_EOL;
             exit(1);
         }

--- a/src/ZM/Event/Listener/WorkerEventListener.php
+++ b/src/ZM/Event/Listener/WorkerEventListener.php
@@ -227,9 +227,14 @@ class WorkerEventListener
                     logger()->info('已加载 ' . $count . ' 个 Composer 插件');
                 }
             }
+            $disable_list = Framework::getInstance()->getArgv()['disable-plugins'];
+            if ($disable_list === null) {
+                $disable_list = '';
+            }
+            $exp = explode(',', $disable_list);
 
             // 启用并初始化插件
-            PluginManager::enablePlugins($parser);
+            PluginManager::enablePlugins($parser, $exp);
         }
 
         // 解析所有注册路径的文件，获取注解

--- a/src/ZM/Event/Listener/WorkerEventListener.php
+++ b/src/ZM/Event/Listener/WorkerEventListener.php
@@ -199,7 +199,7 @@ class WorkerEventListener
                 'command-manual' => new CommandManualPlugin($parser),
                 default => throw new PluginException('Unknown native plugin: ' . $name),
             };
-            $meta = new PluginMeta(['name' => $name], ZM_PLUGIN_TYPE_NATIVE);
+            $meta = new PluginMeta(name: $name, plugin_type: ZM_PLUGIN_TYPE_NATIVE);
             $meta->bindEntity($plugin);
             PluginManager::addPlugin($meta);
         }

--- a/src/ZM/Framework.php
+++ b/src/ZM/Framework.php
@@ -47,7 +47,7 @@ class Framework
     public const VERSION_ID = 697;
 
     /** @var string 版本名称 */
-    public const VERSION = '3.0.3';
+    public const VERSION = '3.1.0';
 
     /** @var array 传入的参数 */
     protected array $argv;

--- a/src/ZM/Plugin/OneBot12Adapter.php
+++ b/src/ZM/Plugin/OneBot12Adapter.php
@@ -219,11 +219,10 @@ class OneBot12Adapter extends ZMPlugin
     /**
      * [CALLBACK] 处理需要等待回复的 bot()->prompt() 会话消息
      *
-     * @param  BotContext         $ctx   机器人上下文
      * @param  OneBotEvent        $event 当前事件对象
      * @throws InterruptException
      */
-    public function handleContextPrompt(BotContext $ctx, OneBotEvent $event)
+    public function handleContextPrompt(OneBotEvent $event)
     {
         // 必须支持协程才能用
         if (($co = Adaptive::getCoroutine()) === null) {

--- a/src/ZM/Plugin/PluginManager.php
+++ b/src/ZM/Plugin/PluginManager.php
@@ -9,6 +9,7 @@ use ZM\Annotation\AnnotationMap;
 use ZM\Annotation\AnnotationParser;
 use ZM\Annotation\Framework\BindEvent;
 use ZM\Command\Command;
+use ZM\Exception\FileSystemException;
 use ZM\Exception\PluginException;
 use ZM\Store\FileSystem;
 use ZM\Store\PharHelper;
@@ -288,6 +289,7 @@ class PluginManager
      * 打包插件到 Phar
      *
      * @throws PluginException
+     * @throws FileSystemException
      */
     public static function packPlugin(string $plugin_name, string $build_dir, ?Command $command_context = null): string
     {

--- a/src/ZM/Plugin/PluginManager.php
+++ b/src/ZM/Plugin/PluginManager.php
@@ -18,6 +18,11 @@ class PluginManager
     /** @var array<string, PluginMeta> 插件信息列表 */
     private static array $plugins = [];
 
+    public static function getPlugins(): array
+    {
+        return self::$plugins;
+    }
+
     /**
      * 传入插件父目录，扫描插件目录下的所有插件并注册添加
      *
@@ -203,9 +208,16 @@ class PluginManager
      * @param  AnnotationParser $parser 传入注解解析器，用于将插件中的事件注解解析出来
      * @throws PluginException
      */
-    public static function enablePlugins(AnnotationParser $parser): void
+    public static function enablePlugins(AnnotationParser $parser, array $disable_list = []): void
     {
         foreach (self::$plugins as $name => $meta) {
+            if (in_array($name, $disable_list)) {
+                $meta->disablePlugin();
+            }
+            if (!$meta->isEnabled()) {
+                logger()->notice('插件 ' . $name . ' 已被禁用');
+                continue;
+            }
             // 除了内建插件外，输出 log 告知启动插件
             if ($meta->getPluginType() !== ZM_PLUGIN_TYPE_NATIVE) {
                 logger()->info('正在启用插件 ' . $name);

--- a/src/ZM/Plugin/PluginMeta.php
+++ b/src/ZM/Plugin/PluginMeta.php
@@ -20,41 +20,22 @@ class PluginMeta implements \JsonSerializable
     /** @var string 插件描述 */
     private string $description;
 
-    /** @var array 插件的依赖列表 */
-    private array $dependencies;
-
     /** @var null|string 插件的根目录 */
     private ?string $root_dir;
 
     /** @var int 插件类型 */
     private int $plugin_type;
 
-    /** @var array 元信息原文 */
-    private array $metas;
-
     private bool $enabled = true;
 
     private ?ZMPlugin $entity = null;
 
-    /**
-     * @param array       $meta        元信息数组格式
-     * @param int         $plugin_type 插件类型
-     * @param null|string $root_dir    插件根目录
-     */
-    public function __construct(array $meta, int $plugin_type = ZM_PLUGIN_TYPE_NATIVE, ?string $root_dir = null)
+    public function __construct(string $name, string $version = '1.0-dev', string $description = '', int $plugin_type = ZM_PLUGIN_TYPE_NATIVE, ?string $root_dir = null)
     {
-        // 设置名称
-        $this->name = $meta['name'] ?? '<anonymous>';
-        // 设置版本
-        $this->version = $meta['version'] ?? '1.0-dev';
-        // 设置描述
-        $this->description = $meta['description'] ?? '';
-        // 设置依赖
-        $this->dependencies = $meta['dependencies'] ?? [];
-        $this->metas = $meta;
-        // 设置插件根目录
+        $this->name = $name;
+        $this->version = $version;
+        $this->description = $description;
         $this->plugin_type = $plugin_type;
-        // 设置插件根目录
         $this->root_dir = $root_dir;
     }
 
@@ -148,11 +129,6 @@ class PluginMeta implements \JsonSerializable
         return $this->description;
     }
 
-    public function getDependencies(): array
-    {
-        return $this->dependencies;
-    }
-
     public function getRootDir(): string
     {
         return $this->root_dir;
@@ -174,13 +150,7 @@ class PluginMeta implements \JsonSerializable
             'name' => $this->name,
             'version' => $this->version,
             'description' => $this->description,
-            'dependencies' => $this->dependencies,
         ];
-    }
-
-    public function getMetas(): array
-    {
-        return $this->metas;
     }
 
     public function getEntity(): ?ZMPlugin

--- a/src/ZM/Plugin/PluginMeta.php
+++ b/src/ZM/Plugin/PluginMeta.php
@@ -32,6 +32,8 @@ class PluginMeta implements \JsonSerializable
     /** @var array 元信息原文 */
     private array $metas;
 
+    private bool $enabled = true;
+
     private ?ZMPlugin $entity = null;
 
     /**
@@ -54,6 +56,21 @@ class PluginMeta implements \JsonSerializable
         $this->plugin_type = $plugin_type;
         // 设置插件根目录
         $this->root_dir = $root_dir;
+    }
+
+    public function enablePlugin(): void
+    {
+        $this->enabled = true;
+    }
+
+    public function disablePlugin(): void
+    {
+        $this->enabled = false;
+    }
+
+    public function isEnabled(): bool
+    {
+        return $this->enabled;
     }
 
     public function bindEntity(ZMPlugin $plugin): void

--- a/src/ZM/Plugin/Strategy/ComposerStrategy.php
+++ b/src/ZM/Plugin/Strategy/ComposerStrategy.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZM\Plugin\Strategy;
+
+class ComposerStrategy extends PluginInstallStrategy
+{
+    public function install(array $option = []): bool
+    {
+        // TODO: Composer 类型的插件还没有实现怎么安装，但很简单。这次 Commit 我偏要鸽！
+        $this->error = 'Not implemented';
+        return false;
+    }
+}

--- a/src/ZM/Plugin/Strategy/GitStrategy.php
+++ b/src/ZM/Plugin/Strategy/GitStrategy.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZM\Plugin\Strategy;
+
+use ZM\Utils\ZMRequest;
+use ZM\Utils\ZMUtil;
+
+class GitStrategy extends PluginInstallStrategy
+{
+    private string $git_api_link = 'https://api.github.com/repos/{owner}/{repo}/contents/composer.json';
+
+    private string $token = '';
+
+    /**
+     * @throws \JsonException
+     */
+    public function install(array $option = []): bool
+    {
+        // 应用 git_api_link
+        if (isset($option['git-api-link'])) {
+            $this->git_api_link = $option['git-api-link'];
+        }
+        if (isset($option['github-token'])) {
+            $this->token = $option['github-token'];
+        }
+
+        $git_url = parse_url($this->input);
+
+        // GitHub 做特殊处理，直接调用 API 检查
+        $is_github = false;
+        $plugin_name = null;
+        if ($git_url['host'] === 'github.com' && ($option['github-skip-check'] ?? false) !== true) {
+            if (!$this->checkGitAPI($git_url, $plugin_name)) {
+                return false;
+            }
+            $is_github = true;
+        }
+
+        // 使用 Composer 管理插件，将仓库链接绑定到 composer.json
+        $this->logger->info('正在使用 Composer 下载并安装插件');
+        $composer = ZMUtil::getComposerMetadata($this->root_composer_path);
+        $origin_composer = $composer;
+        $already_has_repo = false;
+        // 不破坏原有队列，加入 GitHub 的 repo
+        if (!isset($composer['repositories'])) {
+            $composer['repositories'] = [];
+        }
+        if (is_assoc_array($composer['repositories'])) {
+            $composer['repositories'] = [$composer['repositories']];
+        }
+        foreach ($composer['repositories'] as $v) {
+            if (($v['url'] ?? '') === $this->input) {
+                $already_has_repo = true;
+                break;
+            }
+        }
+        if (!$already_has_repo) {
+            $composer['repositories'][] = [
+                'type' => $is_github ? 'github' : 'git',
+                'url' => $this->input,
+                '.belongs' => $plugin_name,
+            ];
+        }
+        // 写入 composer.json
+        if (ZMUtil::putComposerMetadata($this->root_composer_path, $composer) === false) {
+            $this->error = '写入 composer.json 失败';
+            return false;
+        }
+        $env = getenv('COMPOSER_EXECUTABLE');
+        if ($env === false) {
+            $env = 'composer';
+        }
+        if ($plugin_name === null) {
+            $this->error = '没有从 Git 获取到插件的元信息，目前无法从 GitHub 以外的 Git 仓库下载插件，后续会更新！';
+            ZMUtil::putComposerMetadata($this->root_composer_path, $origin_composer);
+            return false;
+        }
+        if ($plugin_name === '') {
+            $this->error = '获取插件名称失败！';
+            ZMUtil::putComposerMetadata($this->root_composer_path, $origin_composer);
+            return false;
+        }
+        if (function_exists('pcntl_signal')) {
+            pcntl_signal(SIGINT, function () use ($origin_composer) {
+                echo "强行中断，恢复 Composer 中\n";
+                ZMUtil::putComposerMetadata($this->root_composer_path, $origin_composer);
+            });
+        }
+        passthru("{$env} require {$plugin_name}", $code);
+        if (function_exists('pcntl_signal')) {
+            pcntl_signal(SIGINT, SIG_IGN);
+        }
+        if ($code !== 0) {
+            $this->error = '使用 composer 引入 Git 插件出现了一些错误，请看上方错误';
+            ZMUtil::putComposerMetadata($this->root_composer_path, $origin_composer);
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * 用于调用 GitHub 的 API 用作不下载就检查插件是否合规
+     *
+     * @param array $git_url 解析后的链接
+     */
+    private function checkGitAPI(array $git_url, ?string &$plugin_name = null): bool
+    {
+        $this->logger->info('正在检查 GitHub 插件是否为框架插件');
+        [, $owner, $repo] = explode('/', $git_url['path']);
+        if (str_ends_with($repo, '.git')) {
+            $repo = substr($repo, 0, -4);
+        }
+
+        // 调用 HTTP 客户端获取 API 信息
+        $header = ['User-Agent' => 'zhamao-framework'];
+        if ($this->token !== '') {
+            $header['Authorization'] = 'token ' . $this->token;
+        }
+        $api = ZMRequest::get(
+            str_replace(['{owner}', '{repo}'], [$owner, $repo], $this->git_api_link),
+            $header,
+            only_body: false
+        );
+        if ($api->getStatusCode() !== 200) {
+            $this->error = "GitHub API 请求失败[{$api->getStatusCode()}]";
+            if ($api->getStatusCode() === 403) {
+                $this->error .= '可能是 API 滥用导致的，建议生成一个 GitHub Token。';
+            }
+            return false;
+        }
+
+        // 检查插件的 composer.json 是否合规
+        $content = json_decode($api->getBody()->getContents(), true);
+        if (isset($content['message'])) {
+            $this->error = '该 GitHub 仓库中不存在 composer.json 文件！';
+            return false;
+        }
+        $contents = implode('', array_map(fn ($x) => base64_decode($x), explode("\n", $content['content'])));
+        $json = json_decode($contents, true);
+        if (!$this->checkComposerIntegrity($json)) {
+            return false;
+        }
+        $plugin_name = $json['name'];
+        $this->installed_name = $plugin_name;
+        return true;
+    }
+}

--- a/src/ZM/Plugin/Strategy/PluginInstallStrategy.php
+++ b/src/ZM/Plugin/Strategy/PluginInstallStrategy.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZM\Plugin\Strategy;
+
+use Psr\Log\LoggerInterface;
+use ZM\Plugin\PluginManager;
+
+abstract class PluginInstallStrategy
+{
+    protected string $error = '';
+
+    protected string $installed_name = '';
+
+    public function __construct(
+        protected string $input,
+        protected string $plugin_dir,
+        protected string $root_composer_path = '',
+        protected ?LoggerInterface $logger = null,
+    ) {
+        if ($this->root_composer_path === '') {
+            $this->root_composer_path = zm_dir(WORKING_DIR);
+        }
+        if ($this->logger === null) {
+            $this->logger = ob_logger();
+        }
+    }
+
+    abstract public function install(array $option = []): bool;
+
+    public function getError(): string
+    {
+        return $this->error;
+    }
+
+    public function getInstalledName(): string
+    {
+        return $this->installed_name;
+    }
+
+    /**
+     * 用于检查 Composer 文件的信息是否完整
+     */
+    protected function checkComposerIntegrity(mixed $composer): bool
+    {
+        // 必须是 array
+        if (!is_array($composer)) {
+            $this->error = 'composer.json 元信息获取出错';
+            return false;
+        }
+        if (!isset($composer['extra']['zm-plugin-version'])) {
+            $this->error = 'composer.json 内没有标明该炸毛插件的版本，或该仓库不是炸毛插件';
+            return false;
+        }
+        if (!isset($composer['name'])) {
+            $this->error = 'composer.json 插件元信息内没有名字！';
+            return false;
+        }
+        $plugin_name = $composer['name'];
+        if (PluginManager::isPluginExists($plugin_name)) {
+            $this->error = "插件 {$plugin_name} 已存在，无法再次安装";
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/ZM/Utils/CodeGenerator/PluginGenerator.php
+++ b/src/ZM/Utils/CodeGenerator/PluginGenerator.php
@@ -23,7 +23,7 @@ class PluginGenerator
      * @param  array               $options 传入的命令行选项
      * @throws FileSystemException
      */
-    public function generate(array $options): void
+    public function generate(array $options): string
     {
         // 先检查插件目录是否存在，不存在则创建
         FileSystem::createDir($this->plugin_dir);
@@ -87,6 +87,7 @@ class PluginGenerator
         }
         passthru(PHP_BINARY . ' ' . escapeshellcmd($env) . ' dump-autoload');
         chdir(WORKING_DIR);
+        return $plugin_base_dir;
     }
 
     /**

--- a/src/ZM/Utils/ZMUtil.php
+++ b/src/ZM/Utils/ZMUtil.php
@@ -16,4 +16,15 @@ class ZMUtil
     {
         return json_decode(file_get_contents(($path ?? SOURCE_ROOT_DIR) . '/composer.json'), true, 512, JSON_THROW_ON_ERROR);
     }
+
+    /**
+     * 写入 composer.json
+     *
+     * @param null|string $path    路径
+     * @param array       $content 内容数组
+     */
+    public static function putComposerMetadata(?string $path = null, array $content = []): false|int
+    {
+        return file_put_contents(($path ?? SOURCE_ROOT_DIR) . '/composer.json', json_encode($content, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+    }
 }

--- a/src/ZM/ZMApplication.php
+++ b/src/ZM/ZMApplication.php
@@ -50,7 +50,7 @@ class ZMApplication extends ZMPlugin
      */
     public function run()
     {
-        $meta = new PluginMeta(['name' => 'native'], ZM_PLUGIN_TYPE_NATIVE);
+        $meta = new PluginMeta(name: 'native', plugin_type: ZM_PLUGIN_TYPE_NATIVE);
         $meta->bindEntity($this);
         PluginManager::addPlugin($meta);
         (new Framework($this->args))->init()->start();


### PR DESCRIPTION
- [X] 插件列表命令
- [x] 插件生成器重构：创建目录要变成但级目录
- [x] 插件生成器重构：检测并兼容旧版插件（zmplugin.json）
- [ ] 插件生成器重构：帮助生成插件的 Git 仓库、GitHub Action、.gitignore 等文件