### PR TITLE
V2 修复使用go()函数并发调用接口时丢失返回数据的问题

### DIFF
--- a/src/ZM/ConsoleApplication.php
+++ b/src/ZM/ConsoleApplication.php
@@ -30,7 +30,7 @@ class ConsoleApplication extends Application
 {
     public const VERSION_ID = 480;
 
-    public const VERSION = '2.8.10';
+    public const VERSION = '2.8.11';
 
     private static $obj;
 

--- a/src/ZM/Utils/CoMessage.php
+++ b/src/ZM/Utils/CoMessage.php
@@ -16,7 +16,7 @@ class CoMessage
     /**
      * @return mixed
      */
-    public static function yieldByWS(array $hang, array $compare, int $timeout = 600)
+    public static function yieldByWS(array $hang, array $compare, int $timeout = 600, ?callable $callable = null)
     {
         $cid = Coroutine::getuid();
         $api_id = ZMAtomic::get('wait_msg_id')->add(1);
@@ -29,6 +29,9 @@ class CoMessage
         $wait[$api_id] = $hang;
         LightCacheInside::set('wait_api', 'wait_api', $wait);
         SpinLock::unlock('wait_api');
+        if ($callable instanceof \Closure) {
+            call_user_func($callable);
+        }
         $id = swoole_timer_after($timeout * 1000, function () use ($api_id) {
             $r = LightCacheInside::get('wait_api', 'wait_api')[$api_id] ?? null;
             if (is_array($r)) {


### PR DESCRIPTION
测试代码
``` php
foreach (range(1, 50) as $i) {
            go(function () use ($i) {
                $all = OneBotV11::getAllRobot();
                shuffle($all);
                foreach ($all as $bot) {
                    $list = $bot->getGroupList();
                    if ($list === false) {
                        var_dump('获取失败');
                    }
                }
            });
        }
```
相关issues #277 