### PR TITLE
fix: add SIGHUP/SIGTERM handling, widen PHP to 8.5, modernize CI

### DIFF
--- a/.github/workflows/build-release-artifacts.yml
+++ b/.github/workflows/build-release-artifacts.yml
@@ -12,14 +12,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.base_ref }}
 
       - name: Setup PHP
         uses: sunxyw/workflows/setup-environment@main
         with:
-          php-version: 8.1
+          php-version: 8.3
           php-extensions: swoole, posix, json
           operating-system: ubuntu-latest
           use-cache: true
@@ -40,14 +40,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.base_ref }}
 
       - name: Setup PHP
         uses: sunxyw/workflows/setup-environment@main
         with:
-          php-version: 8.1
+          php-version: 8.3
           php-extensions: swoole, posix, json
           operating-system: ubuntu-latest
           use-cache: true

--- a/.github/workflows/coding-style.yml
+++ b/.github/workflows/coding-style.yml
@@ -27,14 +27,14 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup PHP
         uses: sunxyw/workflows/setup-environment@main
         with:
-          php-version: 8.1
+          php-version: 8.3
           php-extensions: swoole, posix, json
           operating-system: ubuntu-latest
           use-cache: true

--- a/.github/workflows/increment-build-number.yml
+++ b/.github/workflows/increment-build-number.yml
@@ -16,14 +16,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.base_ref }}
 
       - name: Setup PHP
         uses: sunxyw/workflows/setup-environment@main
         with:
-          php-version: 8.1
+          php-version: 8.3
           php-extensions: swoole, posix, json
           operating-system: ubuntu-latest
           use-cache: true

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -27,14 +27,14 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup PHP
         uses: sunxyw/workflows/setup-environment@main
         with:
-          php-version: 8.1
+          php-version: 8.3
           php-extensions: swoole, posix, json
           operating-system: ubuntu-latest
           use-cache: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/vuepress-deploy.yml
+++ b/.github/workflows/vuepress-deploy.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout master
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Deploy docs to GitHub Pages
         uses: jenkey2011/vuepress-deploy@master

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": "^8.0 || ^8.1 || ^8.2",
+        "php": "^8.0 || ^8.1 || ^8.2 || ^8.3 || ^8.4 || ^8.5",
         "ext-json": "*",
         "ext-tokenizer": "*",
         "doctrine/dbal": "^2.13.1",
@@ -35,18 +35,18 @@
     "require-dev": {
         "captainhook/captainhook": "^5.10",
         "captainhook/plugin-composer": "^5.3",
-        "friendsofphp/php-cs-fixer": "^3.2 != 3.7.0",
+        "friendsofphp/php-cs-fixer": "^3.64",
         "jangregor/phpstan-prophecy": "^1.0",
         "jetbrains/phpstorm-attributes": "^1.0",
         "mikey179/vfsstream": "^1.6",
         "phpspec/prophecy-phpunit": "^2.3",
         "phpstan/extension-installer": "^1.1",
-        "phpstan/phpstan": "^1.1",
+        "phpstan/phpstan": "^1.12",
         "phpstan/phpstan-deprecation-rules": "^1.0",
         "phpstan/phpstan-phpunit": "^1.1",
-        "phpunit/phpunit": "^8.5 || ^9.0",
+        "phpunit/phpunit": "^9.0",
         "roave/security-advisories": "dev-latest",
-        "swoole/ide-helper": "^4.5"
+        "swoole/ide-helper": "^5.0"
     },
     "replace": {
         "symfony/polyfill-php80": "*"

--- a/src/Globals/global_functions.php
+++ b/src/Globals/global_functions.php
@@ -301,7 +301,7 @@ function redis(string $name = 'default'): RedisWrapper
  * @param  null|mixed          $default 默认值
  * @return mixed|void|ZMConfig
  */
-function config(null|array|string $key = null, mixed $default = null)
+function config(array|string|null $key = null, mixed $default = null)
 {
     $config = ZMConfig::getInstance();
     if (is_null($key)) {

--- a/src/ZM/Annotation/OneBot/CommandArgument.php
+++ b/src/ZM/Annotation/OneBot/CommandArgument.php
@@ -41,7 +41,7 @@ class CommandArgument extends AnnotationBase implements ErgodicAnnotation
         string $type = 'string',
         public bool $required = false,
         public string $prompt = '',
-        public null|array|\Closure|float|int|string $default = '',
+        public array|\Closure|float|int|string|null $default = '',
         public int $timeout = 60,
         public int $error_prompt_policy = 1
     ) {

--- a/src/ZM/Context/BotContext.php
+++ b/src/ZM/Context/BotContext.php
@@ -87,7 +87,7 @@ class BotContext implements ContextInterface
      * @noinspection PhpDocMissingThrowsInspection
      * @noinspection PhpUnhandledExceptionInspection
      */
-    public function prompt(array|MessageSegment|string|\Stringable $prompt = '', int $timeout = 600, array|MessageSegment|string|\Stringable $timeout_prompt = '', int $option = ZM_PROMPT_NONE): null|array|OneBotEvent|string
+    public function prompt(array|MessageSegment|string|\Stringable $prompt = '', int $timeout = 600, array|MessageSegment|string|\Stringable $timeout_prompt = '', int $option = ZM_PROMPT_NONE): array|OneBotEvent|string|null
     {
         if (!container()->has('bot.event')) {
             throw new OneBot12Exception('bot()->prompt() can only be used in message event');
@@ -268,7 +268,7 @@ class BotContext implements ContextInterface
      * @return null|array|OneBotEvent|string 根据不同匹配类型返回不同的东西
      * @throws OneBot12Exception
      */
-    private function applyPromptReturn(mixed $result, int $option): null|array|OneBotEvent|string
+    private function applyPromptReturn(mixed $result, int $option): array|OneBotEvent|string|null
     {
         // 必须是 OneBotEvent 且是消息类型
         if (!$result instanceof OneBotEvent || $result->type !== 'message') {

--- a/src/ZM/Event/Listener/SignalListener.php
+++ b/src/ZM/Event/Listener/SignalListener.php
@@ -30,10 +30,13 @@ class SignalListener
         switch (Framework::getInstance()->getDriver()->getName()) {
             case 'swoole':
                 Process::signal(SIGINT, [$this, 'onWorkerInt']);
+                Process::signal(SIGTERM, [$this, 'onWorkerInt']);
+                Process::signal(SIGHUP, [$this, 'onWorkerInt']);
                 break;
             case 'workerman':
                 Worker::$globalEvent->add(SIGINT, EventInterface::EV_SIGNAL, [$this, 'onWorkerInt']);
                 Worker::$globalEvent->add(SIGTERM, EventInterface::EV_SIGNAL, fn () => Worker::stopAll(15));
+                Worker::$globalEvent->add(SIGHUP, EventInterface::EV_SIGNAL, fn () => Worker::stopAll(15));
                 if (function_exists('pcntl_signal')) {
                     pcntl_signal(SIGUSR1, SIG_IGN, false);
                 }
@@ -51,10 +54,9 @@ class SignalListener
     {
         $driver = Framework::getInstance()->getDriver()->getName();
         if ($driver === 'swoole') {
-            Process::signal(SIGINT, function () {
+            $stopHandler = function () {
                 echo "\r";
-                logger()->notice('Master 进程收到中断信号 SIGINT');
-                logger()->notice('正在停止服务器');
+                logger()->notice('Master 进程收到中断信号，正在停止服务器');
                 Framework::getInstance()->stop();
                 if (extension_loaded('posix')) {
                     Process::kill(posix_getpid(), SIGTERM);
@@ -62,10 +64,13 @@ class SignalListener
                     /* @phpstan-ignore-next-line */
                     Process::kill(Framework::getInstance()->getDriver()->getSwooleServer()->master_pid, SIGTERM);
                 }
-            });
+            };
+            Process::signal(SIGINT, $stopHandler);
+            Process::signal(SIGTERM, $stopHandler);
+            Process::signal(SIGHUP, $stopHandler);
         } elseif ($driver === 'workerman') {
             if (!extension_loaded('pcntl') || !extension_loaded('posix')) {
-                logger()->error('请安装 pcntl 和 posix 扩展以支持 SIGINT 监听');
+                logger()->error('请安装 pcntl 和 posix 扩展以支持信号监听');
                 return;
             }
 
@@ -73,15 +78,14 @@ class SignalListener
                 logger()->warning('重启ing');
                 Worker::reloadSelf();
             }, false);
-            pcntl_signal(SIGTERM, function () {
-                Worker::stopAll();
-            }, false);
-            pcntl_signal(SIGINT, function () {
+            $stopMaster = function () {
                 echo "\r";
-                logger()->notice('Master 进程收到中断信号 SIGINT');
-                logger()->notice('正在停止服务器');
+                logger()->notice('Master 进程收到中断信号，正在停止服务器');
                 Worker::stopAll();
-            }, false);
+            };
+            pcntl_signal(SIGTERM, $stopMaster, false);
+            pcntl_signal(SIGINT, $stopMaster, false);
+            pcntl_signal(SIGHUP, $stopMaster, false);
         }
     }
 

--- a/src/ZM/Framework.php
+++ b/src/ZM/Framework.php
@@ -50,7 +50,7 @@ class Framework
     public const VERSION_ID = 726;
 
     /** @var string 版本名称 */
-    public const VERSION = '3.2.6';
+    public const VERSION = '3.2.7';
 
     /**
      * @var RuntimePreferences 运行时偏好（环境信息&参数）
@@ -61,7 +61,7 @@ class Framework
     protected array $argv;
 
     /** @var null|Driver|SwooleDriver|WorkermanDriver OneBot驱动 */
-    protected null|Driver|SwooleDriver|WorkermanDriver $driver = null;
+    protected Driver|SwooleDriver|WorkermanDriver|null $driver = null;
 
     /** @var array<array<string, string>> 启动注解列表 */
     protected array $setup_annotations = [];

--- a/src/ZM/Process/ProcessStateManager.php
+++ b/src/ZM/Process/ProcessStateManager.php
@@ -31,7 +31,7 @@ class ProcessStateManager
      * @throws ZMKnownException
      * @internal
      */
-    public static function removeProcessState(int $type, null|int|string $id_or_name = null): void
+    public static function removeProcessState(int $type, int|string|null $id_or_name = null): void
     {
         switch ($type) {
             case ZM_PROCESS_MASTER:

--- a/src/ZM/Store/KV/LightCache.php
+++ b/src/ZM/Store/KV/LightCache.php
@@ -104,7 +104,7 @@ class LightCache implements KVInterface
     /**
      * @throws InvalidArgumentException
      */
-    public function set(string $key, mixed $value, null|\DateInterval|int $ttl = null): bool
+    public function set(string $key, mixed $value, \DateInterval|int|null $ttl = null): bool
     {
         $this->validateKey($key);
         self::$caches[$this->name][$key] = $value;
@@ -139,7 +139,7 @@ class LightCache implements KVInterface
         }
     }
 
-    public function setMultiple(iterable $values, null|\DateInterval|int $ttl = null): bool
+    public function setMultiple(iterable $values, \DateInterval|int|null $ttl = null): bool
     {
         foreach ($values as $k => $v) {
             if (!$this->set($k, $v, $ttl)) {

--- a/src/ZM/Store/KV/Redis/KVRedis.php
+++ b/src/ZM/Store/KV/Redis/KVRedis.php
@@ -35,7 +35,7 @@ class KVRedis implements KVInterface
         return $ret;
     }
 
-    public function set(string $key, mixed $value, null|\DateInterval|int $ttl = null): bool
+    public function set(string $key, mixed $value, \DateInterval|int|null $ttl = null): bool
     {
         /** @var ZMRedis $redis */
         $redis = RedisPool::pool($this->pool_name)->get();
@@ -78,7 +78,7 @@ class KVRedis implements KVInterface
         RedisPool::pool($this->pool_name)->put($redis);
     }
 
-    public function setMultiple(iterable $values, null|\DateInterval|int $ttl = null): bool
+    public function setMultiple(iterable $values, \DateInterval|int|null $ttl = null): bool
     {
         /** @var ZMRedis $redis */
         $redis = RedisPool::pool($this->pool_name)->get();

--- a/src/ZM/Utils/MessageUtil.php
+++ b/src/ZM/Utils/MessageUtil.php
@@ -99,7 +99,7 @@ class MessageUtil
         return $ls;
     }
 
-    public static function getAltMessage(null|array|MessageSegment|string $message): string
+    public static function getAltMessage(array|MessageSegment|string|null $message): string
     {
         if ($message === null) {
             return '';


### PR DESCRIPTION
## 问题

当从 IDE 终端启动框架后直接关闭 IDE（而不先停框架），终端 PTY 被销毁，框架进程无法响应 SIGHUP 信号优雅退出，配合日志递归错误导致 CPU 100% 空耗。

## 修复

### 信号处理（SignalListener）
- **signalWorker()**: Swoole 添加 SIGHUP/SIGTERM；Workerman 添加 SIGHUP
- **signalMaster()**: Swoole 添加 SIGHUP/SIGTERM；Workerman 添加 SIGHUP
- 提取公共 $stopHandler/$stopMaster 闭包，消除重复代码

### PHP 版本
- 版本约束扩至 `^8.3 || ^8.4 || ^8.5`

### CI 现代化
- `actions/checkout@v3` → `@v4`（Node.js 20 deprecated）
- 静态分析/代码风格 PHP: 8.1 → 8.3

## 关联

- libonebot PR: https://github.com/botuniverse/php-libonebot/pull/114
- zhamao-logger PR: https://github.com/zhamao-robot/zhamao-logger/pull/10